### PR TITLE
Remove `Fut` from `FnArgs` in `Injectable` impls for functions

### DIFF
--- a/src/di.rs
+++ b/src/di.rs
@@ -160,7 +160,7 @@ pub type CompiledFn<'a, Output> = Arc<dyn Fn() -> BoxFuture<'a, Output> + Send +
 
 macro_rules! impl_into_di {
     ($($generic:ident),*) => {
-        impl<Func, Input, Output, Fut, $($generic),*>  Injectable<Input, Output, (Fut, $($generic),*)> for Func
+        impl<Func, Input, Output, Fut, $($generic),*>  Injectable<Input, Output, ($($generic,)*)> for Func
         where
             Input: $(DependencySupplier<$generic> +)*,
             Input: Send + Sync,


### PR DESCRIPTION
This was redundant as far as I can tell.