### PR TITLE
Rename `filter{=>_async}`; Add `filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 An implementation of the [chain (tree) of responsibility] pattern.
 
-[[`examples/web_server.rs`](https://github.com/p0lunin/dptree/blob/master/examples/web_server.rs)]
+[[`examples/web_server.rs`](examples/web_server.rs)]
 ```rust
 use dptree::prelude::*;
 
@@ -32,12 +32,12 @@ async fn main() {
 }
 
 fn smiles_handler() -> WebHandler {
-    dptree::filter(|req: &'static str| async move { req.starts_with("/smile") })
+    dptree::filter(|req: &'static str| req.starts_with("/smile"))
         .endpoint(|| async { "🙃".to_owned() })
 }
 
 fn sqrt_handler() -> WebHandler {
-    dptree::filter_map(|req: &'static str| async move {
+    dptree::filter_map(|req: &'static str| {
         if req.starts_with("/sqrt") {
             let (_, n) = req.split_once(' ')?;
             n.parse::<f64>().ok()

--- a/examples/simple_dispatcher.rs
+++ b/examples/simple_dispatcher.rs
@@ -83,7 +83,7 @@ impl Event {
 type CommandHandler = Endpoint<'static, DependencyMap, String>;
 
 fn ping_handler() -> CommandHandler {
-    dptree::filter(|event: Event| async move { matches!(event, Event::Ping) })
+    dptree::filter_async(|event: Event| async move { matches!(event, Event::Ping) })
         .endpoint(|| async { "Pong".to_string() })
 }
 
@@ -101,7 +101,7 @@ fn set_value_handler() -> CommandHandler {
 }
 
 fn print_value_handler() -> CommandHandler {
-    dptree::filter(|event: Event| async move { matches!(event, Event::PrintValue) }).endpoint(
+    dptree::filter_async(|event: Event| async move { matches!(event, Event::PrintValue) }).endpoint(
         move |store: Arc<AtomicI32>| async move {
             let value = store.load(Ordering::SeqCst);
             format!("{}", value)

--- a/examples/simple_dispatcher.rs
+++ b/examples/simple_dispatcher.rs
@@ -88,7 +88,7 @@ fn ping_handler() -> CommandHandler {
 }
 
 fn set_value_handler() -> CommandHandler {
-    dptree::filter_map(|event: Event| async move {
+    dptree::filter_map_async(|event: Event| async move {
         match event {
             Event::SetValue(value) => Some(value),
             _ => None,

--- a/examples/state_machine.rs
+++ b/examples/state_machine.rs
@@ -6,8 +6,6 @@ use std::{
     ops::ControlFlow,
 };
 
-use futures::future;
-
 use dptree::prelude::*;
 
 #[tokio::main]
@@ -106,27 +104,27 @@ mod transitions {
     use super::*;
 
     pub fn begin() -> Transition {
-        dptree::filter(|event: Event| future::ready(matches!(event, Event::Begin)))
+        dptree::filter(|event: Event| matches!(event, Event::Begin))
             .endpoint(|| async { CommandState::Active })
     }
 
     pub fn pause() -> Transition {
-        dptree::filter(|event: Event| future::ready(matches!(event, Event::Pause)))
+        dptree::filter(|event: Event| matches!(event, Event::Pause))
             .endpoint(|| async { CommandState::Paused })
     }
 
     pub fn end() -> Transition {
-        dptree::filter(|event: Event| future::ready(matches!(event, Event::End)))
+        dptree::filter(|event: Event| matches!(event, Event::End))
             .endpoint(|| async { CommandState::Inactive })
     }
 
     pub fn resume() -> Transition {
-        dptree::filter(|event: Event| future::ready(matches!(event, Event::Resume)))
+        dptree::filter(|event: Event| matches!(event, Event::Resume))
             .endpoint(|| async { CommandState::Active })
     }
 
     pub fn exit() -> Transition {
-        dptree::filter(|event: Event| future::ready(matches!(event, Event::Exit)))
+        dptree::filter(|event: Event| matches!(event, Event::Exit))
             .endpoint(|| async { CommandState::Exit })
     }
 }
@@ -134,24 +132,24 @@ mod transitions {
 type FsmHandler = Handler<'static, Store, TransitionOut>;
 
 fn active_handler() -> FsmHandler {
-    dptree::filter(|state: CommandState| future::ready(matches!(state, CommandState::Active)))
+    dptree::filter(|state: CommandState| matches!(state, CommandState::Active))
         .branch(transitions::pause())
         .branch(transitions::end())
 }
 
 fn paused_handler() -> FsmHandler {
-    dptree::filter(|state: CommandState| future::ready(matches!(state, CommandState::Paused)))
+    dptree::filter(|state: CommandState| matches!(state, CommandState::Paused))
         .branch(transitions::resume())
         .branch(transitions::end())
 }
 
 fn inactive_handler() -> FsmHandler {
-    dptree::filter(|state: CommandState| future::ready(matches!(state, CommandState::Inactive)))
+    dptree::filter(|state: CommandState| matches!(state, CommandState::Inactive))
         .branch(transitions::begin())
         .branch(transitions::exit())
 }
 
 fn exit_handler() -> FsmHandler {
-    dptree::filter(|state: CommandState| future::ready(matches!(state, CommandState::Exit)))
+    dptree::filter(|state: CommandState| matches!(state, CommandState::Exit))
         .branch(transitions::exit())
 }

--- a/examples/web_server.rs
+++ b/examples/web_server.rs
@@ -25,7 +25,7 @@ async fn main() {
 }
 
 fn smiles_handler() -> WebHandler {
-    dptree::filter(|req: &'static str| async move { req.starts_with("/smile") })
+    dptree::filter_async(|req: &'static str| async move { req.starts_with("/smile") })
         .endpoint(|| async { "🙃".to_owned() })
 }
 

--- a/examples/web_server.rs
+++ b/examples/web_server.rs
@@ -25,12 +25,12 @@ async fn main() {
 }
 
 fn smiles_handler() -> WebHandler {
-    dptree::filter_async(|req: &'static str| async move { req.starts_with("/smile") })
+    dptree::filter(|req: &'static str| req.starts_with("/smile"))
         .endpoint(|| async { "🙃".to_owned() })
 }
 
 fn sqrt_handler() -> WebHandler {
-    dptree::filter_map_async(|req: &'static str| async move {
+    dptree::filter_map(|req: &'static str| {
         if req.starts_with("/sqrt") {
             let (_, n) = req.split_once(' ')?;
             n.parse::<f64>().ok()

--- a/examples/web_server.rs
+++ b/examples/web_server.rs
@@ -30,7 +30,7 @@ fn smiles_handler() -> WebHandler {
 }
 
 fn sqrt_handler() -> WebHandler {
-    dptree::filter_map(|req: &'static str| async move {
+    dptree::filter_map_async(|req: &'static str| async move {
         if req.starts_with("/sqrt") {
             let (_, n) = req.split_once(' ')?;
             n.parse::<f64>().ok()

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -50,8 +50,7 @@ where
     /// # async fn main() {
     /// use dptree::prelude::*;
     ///
-    /// let handler =
-    ///     dptree::filter(|x: i32| async move { x > 0 }).chain(dptree::endpoint(|| async { "done" }));
+    /// let handler = dptree::filter(|x: i32| x > 0).chain(dptree::endpoint(|| async { "done" }));
     ///
     /// assert_eq!(handler.dispatch(dptree::deps![10]).await, ControlFlow::Break("done"));
     /// assert_eq!(
@@ -107,18 +106,9 @@ where
     /// }
     ///
     /// let dispatcher = dptree::entry()
-    ///     .branch(
-    ///         dptree::filter(|num: i32| async move { num == 5 })
-    ///             .endpoint(|| async move { Output::Five }),
-    ///     )
-    ///     .branch(
-    ///         dptree::filter(|num: i32| async move { num == 1 })
-    ///             .endpoint(|| async move { Output::One }),
-    ///     )
-    ///     .branch(
-    ///         dptree::filter(|num: i32| async move { num > 2 })
-    ///             .endpoint(|| async move { Output::GT }),
-    ///     );
+    ///     .branch(dptree::filter(|num: i32| num == 5).endpoint(|| async move { Output::Five }))
+    ///     .branch(dptree::filter(|num: i32| num == 1).endpoint(|| async move { Output::One }))
+    ///     .branch(dptree::filter(|num: i32| num > 2).endpoint(|| async move { Output::GT }));
     ///
     /// assert_eq!(dispatcher.dispatch(dptree::deps![5]).await, ControlFlow::Break(Output::Five));
     /// assert_eq!(dispatcher.dispatch(dptree::deps![1]).await, ControlFlow::Break(Output::One));
@@ -169,7 +159,7 @@ where
     /// # async fn main() {
     /// use dptree::prelude::*;
     ///
-    /// let handler = dptree::filter(|x: i32| async move { x > 0 });
+    /// let handler = dptree::filter(|x: i32| x > 0);
     ///
     /// let output = handler.execute(dptree::deps![10], |_| async { ControlFlow::Break("done") }).await;
     /// assert_eq!(output, ControlFlow::Break("done"));
@@ -231,7 +221,7 @@ where
 mod tests {
     use crate::{
         deps,
-        handler::{endpoint, filter},
+        handler::{endpoint, filter, filter_async},
     };
 
     use super::*;
@@ -305,19 +295,20 @@ mod tests {
             GT,
         }
 
-        let negative_handler = filter(|num: i32| async move { num < 0 })
+        let negative_handler = filter(|num: i32| num < 0)
             .branch(
-                filter(|num: i32| async move { num == -1 })
+                filter_async(|num: i32| async move { num == -1 })
                     .endpoint(|| async move { Output::MinusOne }),
             )
             .branch(endpoint(|| async move { Output::LT }));
 
-        let zero_handler =
-            filter(|num: i32| async move { num == 0 }).endpoint(|| async move { Output::Zero });
+        let zero_handler = filter_async(|num: i32| async move { num == 0 })
+            .endpoint(|| async move { Output::Zero });
 
-        let positive_handler = filter(|num: i32| async move { num > 0 })
+        let positive_handler = filter_async(|num: i32| async move { num > 0 })
             .branch(
-                filter(|num: i32| async move { num == 1 }).endpoint(|| async move { Output::One }),
+                filter_async(|num: i32| async move { num == 1 })
+                    .endpoint(|| async move { Output::One }),
             )
             .branch(endpoint(|| async move { Output::GT }));
 

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -16,23 +16,7 @@ where
     Input: Send + Sync + 'a,
     Output: Send + Sync + 'a,
 {
-    let pred = Arc::new(Asyncify(pred));
-
-    from_fn(move |event, cont| {
-        let pred = Arc::clone(&pred);
-
-        async move {
-            let pred = pred.inject(&event);
-            let cond = pred().await;
-            drop(pred);
-
-            if cond {
-                cont(event).await
-            } else {
-                ControlFlow::Continue(event)
-            }
-        }
-    })
+    filter_async(Asyncify(pred))
 }
 
 /// Constructs a handler that filters input with the predicate `pred`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! }
 //!
 //! fn smiles_handler() -> WebHandler {
-//!     dptree::filter(|req: &'static str| async move { req.starts_with("/smile") })
+//!     dptree::filter(|req: &'static str| req.starts_with("/smile"))
 //!         .endpoint(|| async { "🙃".to_owned() })
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! }
 //!
 //! fn sqrt_handler() -> WebHandler {
-//!     dptree::filter_map(|req: &'static str| async move {
+//!     dptree::filter_map(|req: &'static str| {
 //!         if req.starts_with("/sqrt") {
 //!             let (_, n) = req.split_once(' ')?;
 //!             n.parse::<f64>().ok()


### PR DESCRIPTION
- Rename `filter` => `filter_async`
- Add `filter` (synchronous version of `filter_async`)
- Rename `filter_map` => `filter_map_async`
- Add `filter_map` (synchronous version of `filter_map_async`)
