### PR TITLE
Emit available types on DI panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## unreleased
+
+### Fixed
+
+ - Emit a full list of available types on `DependencyMap::get` panic ([PR #6](https://github.com/p0lunin/dptree/pull/6)).
+
+## 0.1.0 - 2022-02-05
+
+### Added
+
+ - This badass library.

--- a/src/di.rs
+++ b/src/di.rs
@@ -73,7 +73,15 @@ pub trait DependencySupplier<Value> {
 /// use dptree::di::{DependencyMap, DependencySupplier};
 /// let mut container = DependencyMap::new();
 /// container.insert(10i32);
+/// container.insert(true);
+/// container.insert("static str");
 ///
+/// // thread 'main' panicked at 'alloc::string::String was requested, but not provided. Available types:
+/// //    &str
+/// //    bool
+/// //    i32
+/// // ', /media/hirrolot/772CF8924BEBB279/Documents/Rust/dptree/src/di.rs:150:17
+/// // note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 /// let string: Arc<String> = container.get();
 /// ```
 #[derive(Default, Clone)]


### PR DESCRIPTION
Now `DependencySupplier` includes available types in a panic message:

```
thread 'main' panicked at 'i32 was requested, but not provided. Available types:
    state_machine::Event
    state_machine::CommandState
', /media/hirrolot/772CF8924BEBB279/Documents/Rust/dptree/src/di.rs:148:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
