### PR TITLE
Allow scatter-gather injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+
+ - Allow scatter-gather injection via `DependencyMap::insert_container` ([PR #7](https://github.com/p0lunin/dptree/pull/7)).
+
 ## 0.1.1 - 2022-03-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - Allow scatter-gather injection via `DependencyMap::insert_container` ([PR #7](https://github.com/p0lunin/dptree/pull/7)).
+ - `DependencyMap::insert_container` ([PR #7](https://github.com/p0lunin/dptree/pull/7)).
 
 ## 0.1.1 - 2022-03-21
 

--- a/src/di.rs
+++ b/src/di.rs
@@ -349,6 +349,6 @@ mod tests {
         map.insert("hello world");
         map.insert_container(deps![true]);
 
-        assert_eq!(map.get(), Arc::new(String::new()));
+        assert_eq!(map.get(), Arc::new(true));
     }
 }


### PR DESCRIPTION
Allow `DependencyMap` to include other dependency maps. This helps to avoid unnecessary cloning like [here](https://github.com/teloxide/teloxide/blob/f9279f593822d48c1418ee94356a24a12adada67/src/dispatching2/dispatcher.rs#L233).
