### PR TITLE
Add support for the `wasm32-unknown-unknown` target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,35 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Clippy
-      run: cargo clippy --all --all-features --all-targets --examples
-    - name: Tests
-      run: cargo test --all
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Clippy
+        run: cargo clippy --all --all-features --all-targets --examples
+      - name: Tests
+        run: cargo test --all
+
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Clippy (wasm32)
+        run: cargo clippy --all --all-features --all-targets --examples --target wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Tests (wasm32, node)
+        # doctests aren't run here: rustdoc's doctest harness doesn't integrate
+        # cleanly with wasm-bindgen-test-runner (should_panic detection breaks).
+        # Doctests are still covered by the native `build` job above so it should be safe.
+        run: wasm-pack test --node --lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
  - Support for the trailing comma in the `deps` macro ([PR #37](https://github.com/teloxide/dptree/pull/37)).
+ - Support for the `wasm32-unknown-unknown` target via `MaybeSend`/`MaybeSync` traits and a conditional `BoxFuture` alias ([PR #38](https://github.com/teloxide/dptree/issues/38)).
 
 ## 0.5.1 - 2025-07-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 colored = "3"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1", features = ["rt", "macros", "sync"] }
 maplit = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/diagnostics.rs
+++ b/examples/diagnostics.rs
@@ -9,7 +9,7 @@ struct C;
 #[derive(Clone)]
 struct D;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let h: Handler<D> = dptree::entry().map(|_: A| B).inspect(|_: C| ()).endpoint(|| async { D });
 

--- a/examples/simple_dispatcher.rs
+++ b/examples/simple_dispatcher.rs
@@ -27,7 +27,7 @@ use std::{
 
 use dptree::prelude::*;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let store = Arc::new(AtomicI32::new(0));
 

--- a/examples/state_machine.rs
+++ b/examples/state_machine.rs
@@ -8,7 +8,7 @@ use std::{
 
 use dptree::prelude::*;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let state = CommandState::Inactive;
 

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -1,10 +1,14 @@
-use dptree::prelude::*;
-use std::net::Ipv4Addr;
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    // This example uses tokio::spawn/multithreading, which isn't
+    // supported on wasm32-unknown-unknown.
+}
 
+#[cfg(not(target_arch = "wasm32"))]
 fn assert_num_string_handler(
     expected_num: u32,
     expected_string: &'static str,
-) -> Endpoint<'static, ()> {
+) -> dptree::Endpoint<'static, ()> {
     // The handler requires `u32` and `String` types from the input storage.
     dptree::endpoint(move |num: u32, string: String| async move {
         assert_eq!(num, expected_num);
@@ -12,7 +16,8 @@ fn assert_num_string_handler(
     })
 }
 
-#[tokio::main]
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     // Init the storage with `u32` and `String` values.
     let store = dptree::deps![10u32, "Hello".to_owned()];
@@ -23,9 +28,10 @@ async fn main() {
 
     // This will cause a panic because we do not store `Ipv4Addr` in out store.
     let handle = tokio::spawn(async move {
-        let ip_handler: Endpoint<_> = dptree::endpoint(|ip: Ipv4Addr| async move {
-            assert_eq!(ip, Ipv4Addr::new(0, 0, 0, 0));
-        });
+        let ip_handler: dptree::Endpoint<_> =
+            dptree::endpoint(|ip: std::net::Ipv4Addr| async move {
+                assert_eq!(ip, std::net::Ipv4Addr::new(0, 0, 0, 0));
+            });
         let _ = ip_handler.dispatch(store).await;
     });
     let result = handle.await;

--- a/examples/web_server.rs
+++ b/examples/web_server.rs
@@ -3,7 +3,7 @@ use dptree::prelude::*;
 type WebHandler = Endpoint<'static, String>;
 
 #[rustfmt::skip]
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let web_server = dptree::entry()
         .branch(smiles_handler())

--- a/src/di.rs
+++ b/src/di.rs
@@ -311,41 +311,37 @@ macro_rules! deps {
 mod tests {
     use super::*;
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    fn get() {
-        let mut map = DependencyMap::new();
-        map.insert(42i32);
-        map.insert("hello world");
-        map.insert_container(deps![true]);
+    crate::cross_test! {
+        fn get() {
+            let mut map = DependencyMap::new();
+            map.insert(42i32);
+            map.insert("hello world");
+            map.insert_container(deps![true]);
 
-        assert_eq!(map.get(), Arc::new(42i32));
-        assert_eq!(map.get(), Arc::new("hello world"));
-        assert_eq!(map.get(), Arc::new(true));
-    }
+            assert_eq!(map.get(), Arc::new(42i32));
+            assert_eq!(map.get(), Arc::new("hello world"));
+            assert_eq!(map.get(), Arc::new(true));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    fn try_get() {
-        let mut map = DependencyMap::new();
-        assert_eq!(map.try_get::<i32>(), None);
-        map.insert(42i32);
-        assert_eq!(map.try_get(), Some(Arc::new(42i32)));
-        assert_eq!(map.try_get::<f32>(), None);
-    }
+        fn try_get() {
+            let mut map = DependencyMap::new();
+            assert_eq!(map.try_get::<i32>(), None);
+            map.insert(42i32);
+            assert_eq!(map.try_get(), Some(Arc::new(42i32)));
+            assert_eq!(map.try_get::<f32>(), None);
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    fn same_keys() {
-        let mut map_bool1 = DependencyMap::new();
-        let mut map_bool2 = DependencyMap::new();
-        let map_empty = DependencyMap::new();
+        fn same_keys() {
+            let mut map_bool1 = DependencyMap::new();
+            let mut map_bool2 = DependencyMap::new();
+            let map_empty = DependencyMap::new();
 
-        map_bool1.insert(false);
-        map_bool2.insert(true);
+            map_bool1.insert(false);
+            map_bool2.insert(true);
 
-        assert_eq!(map_bool1, map_bool2);
-        assert_ne!(map_bool1, map_empty);
-        assert_ne!(map_bool2, map_empty);
+            assert_eq!(map_bool1, map_bool2);
+            assert_ne!(map_bool1, map_empty);
+            assert_ne!(map_bool2, map_empty);
+        }
     }
 }

--- a/src/di.rs
+++ b/src/di.rs
@@ -13,7 +13,9 @@
 //! [dependency injection]: https://en.wikipedia.org/wiki/Dependency_injection
 //! [this discussion on StackOverflow]: https://stackoverflow.com/questions/130794/what-is-dependency-injection
 
-use futures::future::{ready, BoxFuture};
+use futures::future::ready;
+
+use crate::send::{BoxFuture, MaybeSend, MaybeSync};
 
 use std::{
     any::{Any, TypeId},
@@ -93,7 +95,7 @@ impl PartialEq for DependencyMap {
     fn eq(&self, other: &Self) -> bool {
         let keys1 = self.map.keys();
         let keys2 = other.map.keys();
-        keys1.len() == keys2.len() && keys1.zip(keys2).map(|(k1, k2)| k1 == k2).all(|x| x)
+        keys1.len() == keys2.len() && keys1.zip(keys2).all(|(k1, k2)| k1 == k2)
     }
 }
 
@@ -201,7 +203,10 @@ where
 }
 
 /// A function with all dependencies satisfied.
+#[cfg(not(target_arch = "wasm32"))]
 pub type CompiledFn<'a, Output> = Arc<dyn Fn() -> BoxFuture<'a, Output> + Send + Sync + 'a>;
+#[cfg(target_arch = "wasm32")]
+pub type CompiledFn<'a, Output> = Arc<dyn Fn() -> crate::BoxFuture<'a, Output> + 'a>;
 
 /// Turns a synchronous function into a type that implements [`Injectable`].
 pub struct Asyncify<F>(pub F);
@@ -210,8 +215,8 @@ macro_rules! impl_into_di {
     ($($generic:ident),*) => {
         impl<Func, Output, Fut, $($generic),*> Injectable<Output, ($($generic,)*)> for Func
         where
-            Func: Fn($($generic),*) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Output> + Send + 'static,
+            Func: Fn($($generic),*) -> Fut + MaybeSend + MaybeSync + 'static,
+            Fut: Future<Output = Output> + MaybeSend + 'static,
             Output: 'static,
             $($generic: Clone + Send + Sync + 'static),*
         {
@@ -234,8 +239,8 @@ macro_rules! impl_into_di {
 
         impl<Func, Output, $($generic),*> Injectable<Output, ($($generic,)*)> for Asyncify<Func>
         where
-            Func: Fn($($generic),*) -> Output + Send + Sync + 'static,
-            Output: Send + 'static,
+            Func: Fn($($generic),*) -> Output + MaybeSend + MaybeSync + 'static,
+            Output: MaybeSend + 'static,
             $($generic: Clone + Send + Sync + 'static),*
         {
             #[allow(non_snake_case)]

--- a/src/di.rs
+++ b/src/di.rs
@@ -206,7 +206,7 @@ where
 #[cfg(not(target_arch = "wasm32"))]
 pub type CompiledFn<'a, Output> = Arc<dyn Fn() -> BoxFuture<'a, Output> + Send + Sync + 'a>;
 #[cfg(target_arch = "wasm32")]
-pub type CompiledFn<'a, Output> = Arc<dyn Fn() -> crate::BoxFuture<'a, Output> + 'a>;
+pub type CompiledFn<'a, Output> = Arc<dyn Fn() -> BoxFuture<'a, Output> + 'a>;
 
 /// Turns a synchronous function into a type that implements [`Injectable`].
 pub struct Asyncify<F>(pub F);
@@ -311,7 +311,8 @@ macro_rules! deps {
 mod tests {
     use super::*;
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn get() {
         let mut map = DependencyMap::new();
         map.insert(42i32);
@@ -323,7 +324,8 @@ mod tests {
         assert_eq!(map.get(), Arc::new(true));
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn try_get() {
         let mut map = DependencyMap::new();
         assert_eq!(map.try_get::<i32>(), None);
@@ -332,7 +334,8 @@ mod tests {
         assert_eq!(map.try_get::<f32>(), None);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn same_keys() {
         let mut map_bool1 = DependencyMap::new();
         let mut map_bool2 = DependencyMap::new();

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -667,313 +667,298 @@ mod tests {
 
     use maplit::{btreemap, btreeset, hashset};
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_from_fn_break() {
-        let input = 123;
-        let output = "ABC";
+    crate::cross_test! {
+        async fn test_from_fn_break() {
+            let input = 123;
+            let output = "ABC";
 
-        let input_types = [Type::of::<i32>()];
-        let location = Location::caller();
+            let input_types = [Type::of::<i32>()];
+            let location = Location::caller();
 
-        let result = help_inference(from_fn(
-            |event, _cont: Cont<&'static str>| async move {
-                assert_eq!(event, deps![input]);
-                ControlFlow::Break(output)
-            },
-            HandlerSignature::Other {
-                obligations: BTreeMap::from_iter(
-                    input_types.iter().cloned().map(|ty| (ty, location)),
-                ),
-                guaranteed_outcomes: btreeset! {},
-                conditional_outcomes: btreeset! {},
-                continues: false,
-            },
-        ))
-        .dispatch(deps![input])
-        .await;
+            let result = help_inference(from_fn(
+                |event, _cont: Cont<&'static str>| async move {
+                    assert_eq!(event, deps![input]);
+                    ControlFlow::Break(output)
+                },
+                HandlerSignature::Other {
+                    obligations: BTreeMap::from_iter(
+                        input_types.iter().cloned().map(|ty| (ty, location)),
+                    ),
+                    guaranteed_outcomes: btreeset! {},
+                    conditional_outcomes: btreeset! {},
+                    continues: false,
+                },
+            ))
+            .dispatch(deps![input])
+            .await;
 
-        assert!(result == ControlFlow::Break(output));
-    }
+            assert!(result == ControlFlow::Break(output));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_from_fn_continue() {
-        let input = 123;
-        type Output = &'static str;
+        async fn test_from_fn_continue() {
+            let input = 123;
+            type Output = &'static str;
 
-        let input_types = [Type::of::<i32>()];
-        let location = Location::caller();
+            let input_types = [Type::of::<i32>()];
+            let location = Location::caller();
 
-        let result = help_inference(from_fn(
-            |event, _cont: Cont<&'static str>| async move {
-                assert_eq!(event, deps![input]);
-                ControlFlow::<Output, _>::Continue(event)
-            },
-            HandlerSignature::Other {
-                obligations: BTreeMap::from_iter(
-                    input_types.iter().cloned().map(|ty| (ty, location)),
-                ),
-                guaranteed_outcomes: btreeset! {Type::of::<i32>()},
-                conditional_outcomes: btreeset! {},
-                continues: true,
-            },
-        ))
-        .dispatch(deps![input])
-        .await;
+            let result = help_inference(from_fn(
+                |event, _cont: Cont<&'static str>| async move {
+                    assert_eq!(event, deps![input]);
+                    ControlFlow::<Output, _>::Continue(event)
+                },
+                HandlerSignature::Other {
+                    obligations: BTreeMap::from_iter(
+                        input_types.iter().cloned().map(|ty| (ty, location)),
+                    ),
+                    guaranteed_outcomes: btreeset! {Type::of::<i32>()},
+                    conditional_outcomes: btreeset! {},
+                    continues: true,
+                },
+            ))
+            .dispatch(deps![input])
+            .await;
 
-        assert!(result == ControlFlow::Continue(deps![input]));
-    }
+            assert!(result == ControlFlow::Continue(deps![input]));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_entry() {
-        let input = 123;
-        type Output = &'static str;
+        async fn test_entry() {
+            let input = 123;
+            type Output = &'static str;
 
-        let result = help_inference(entry::<Output, _>()).dispatch(deps![input]).await;
+            let result = help_inference(entry::<Output, _>()).dispatch(deps![input]).await;
 
-        assert!(result == ControlFlow::Continue(deps![input]));
-    }
+            assert!(result == ControlFlow::Continue(deps![input]));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_execute() {
-        let input = 123;
-        let output = "ABC";
+        async fn test_execute() {
+            let input = 123;
+            let output = "ABC";
 
-        let input_types = [Type::of::<i32>()];
-        let location = Location::caller();
+            let input_types = [Type::of::<i32>()];
+            let location = Location::caller();
 
-        let result = help_inference(from_fn(
-            |event, cont| {
+            let result = help_inference(from_fn(
+                |event, cont| {
+                    assert!(event == deps![input]);
+                    cont(event)
+                },
+                HandlerSignature::Other {
+                    obligations: BTreeMap::from_iter(
+                        input_types.iter().cloned().map(|ty| (ty, location)),
+                    ),
+                    guaranteed_outcomes: btreeset! {Type::of::<i32>()},
+                    conditional_outcomes: btreeset! {},
+                    continues: true,
+                },
+            ))
+            .execute(deps![input], |event| async move {
                 assert!(event == deps![input]);
-                cont(event)
-            },
-            HandlerSignature::Other {
-                obligations: BTreeMap::from_iter(
-                    input_types.iter().cloned().map(|ty| (ty, location)),
-                ),
-                guaranteed_outcomes: btreeset! {Type::of::<i32>()},
-                conditional_outcomes: btreeset! {},
-                continues: true,
-            },
-        ))
-        .execute(deps![input], |event| async move {
-            assert!(event == deps![input]);
-            ControlFlow::Break(output)
-        })
-        .await;
-
-        assert!(result == ControlFlow::Break(output));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_deeply_nested_tree() {
-        #[derive(Debug, PartialEq)]
-        enum Output {
-            LT,
-            MinusOne,
-            Zero,
-            One,
-            GT,
-        }
-
-        let negative_handler = filter(|num: i32| num < 0)
-            .branch(
-                filter_async(|num: i32| async move { num == -1 })
-                    .endpoint(|| async move { Output::MinusOne }),
-            )
-            .branch(endpoint(|| async move { Output::LT }));
-
-        let zero_handler = filter_async(|num: i32| async move { num == 0 })
-            .endpoint(|| async move { Output::Zero });
-
-        let positive_handler = filter_async(|num: i32| async move { num > 0 })
-            .branch(
-                filter_async(|num: i32| async move { num == 1 })
-                    .endpoint(|| async move { Output::One }),
-            )
-            .branch(endpoint(|| async move { Output::GT }));
-
-        let dispatcher = help_inference(entry())
-            .branch(negative_handler)
-            .branch(zero_handler)
-            .branch(positive_handler);
-
-        assert_eq!(dispatcher.dispatch(deps![2]).await, ControlFlow::Break(Output::GT));
-        assert_eq!(dispatcher.dispatch(deps![1]).await, ControlFlow::Break(Output::One));
-        assert_eq!(dispatcher.dispatch(deps![0]).await, ControlFlow::Break(Output::Zero));
-        assert_eq!(dispatcher.dispatch(deps![-1]).await, ControlFlow::Break(Output::MinusOne));
-        assert_eq!(dispatcher.dispatch(deps![-2]).await, ControlFlow::Break(Output::LT));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn allowed_updates() {
-        use crate::description::{EventKind, InterestSet};
-        use UpdateKind::*;
-
-        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-        enum UpdateKind {
-            A,
-            B,
-            C,
-        }
-
-        impl EventKind for UpdateKind {
-            fn full_set() -> HashSet<Self> {
-                hashset! { A, B, C }
-            }
-
-            fn empty_set() -> HashSet<Self> {
-                hashset! {}
-            }
-        }
-
-        #[derive(Clone)]
-        #[allow(dead_code)]
-        enum Update {
-            A(i32),
-            B(u8),
-            C(u64),
-        }
-
-        fn filter_a<Out>() -> Handler<'static, Out, InterestSet<UpdateKind>>
-        where
-            Out: Send + Sync + 'static,
-        {
-            filter_map_with_description(
-                InterestSet::new_filter(hashset! { A }),
-                |update: Update| match update {
-                    Update::A(x) => Some(x),
-                    _ => None,
-                },
-            )
-        }
-
-        fn filter_b<Out>() -> Handler<'static, Out, InterestSet<UpdateKind>>
-        where
-            Out: Send + Sync + 'static,
-        {
-            filter_map_with_description(
-                InterestSet::new_filter(hashset! { B }),
-                |update: Update| match update {
-                    Update::B(x) => Some(x),
-                    _ => None,
-                },
-            )
-        }
-
-        fn filter_c<Out>() -> Handler<'static, Out, InterestSet<UpdateKind>>
-        where
-            Out: Send + Sync + 'static,
-        {
-            filter_map_with_description(
-                InterestSet::new_filter(hashset! { C }),
-                |update: Update| match update {
-                    Update::B(x) => Some(x),
-                    _ => None,
-                },
-            )
-        }
-
-        // User-defined filter that doesn't provide allowed updates
-        fn user_defined_filter<Out>() -> Handler<'static, Out, InterestSet<UpdateKind>>
-        where
-            Out: Send + Sync + 'static,
-        {
-            filter_map(|update: Update| match update {
-                Update::B(x) => Some(x),
-                _ => None,
+                ControlFlow::Break(output)
             })
+            .await;
+
+            assert!(result == ControlFlow::Break(output));
         }
 
-        #[track_caller]
-        fn assert(
-            handler: Handler<'static, (), description::InterestSet<UpdateKind>>,
-            allowed: HashSet<UpdateKind>,
-        ) {
-            assert_eq!(handler.description().observed, allowed);
+        async fn test_deeply_nested_tree() {
+            #[derive(Debug, PartialEq)]
+            enum Output {
+                LT,
+                MinusOne,
+                Zero,
+                One,
+                GT,
+            }
+
+            let negative_handler = filter(|num: i32| num < 0)
+                .branch(
+                    filter_async(|num: i32| async move { num == -1 })
+                        .endpoint(|| async move { Output::MinusOne }),
+                )
+                .branch(endpoint(|| async move { Output::LT }));
+
+            let zero_handler = filter_async(|num: i32| async move { num == 0 })
+                .endpoint(|| async move { Output::Zero });
+
+            let positive_handler = filter_async(|num: i32| async move { num > 0 })
+                .branch(
+                    filter_async(|num: i32| async move { num == 1 })
+                        .endpoint(|| async move { Output::One }),
+                )
+                .branch(endpoint(|| async move { Output::GT }));
+
+            let dispatcher = help_inference(entry())
+                .branch(negative_handler)
+                .branch(zero_handler)
+                .branch(positive_handler);
+
+            assert_eq!(dispatcher.dispatch(deps![2]).await, ControlFlow::Break(Output::GT));
+            assert_eq!(dispatcher.dispatch(deps![1]).await, ControlFlow::Break(Output::One));
+            assert_eq!(dispatcher.dispatch(deps![0]).await, ControlFlow::Break(Output::Zero));
+            assert_eq!(dispatcher.dispatch(deps![-1]).await, ControlFlow::Break(Output::MinusOne));
+            assert_eq!(dispatcher.dispatch(deps![-2]).await, ControlFlow::Break(Output::LT));
         }
 
-        // Filters do not observe anything on their own.
-        assert(filter_a(), hashset! {});
-        assert(entry().chain(filter_b()), hashset! {});
-        assert(filter_a().chain(filter_b()), hashset! {});
-        assert(filter_a().branch(filter_b()), hashset! {});
-        assert(filter_a().branch(filter_b()).branch(filter_c().chain(filter_c())), hashset! {});
+        async fn allowed_updates() {
+            use crate::description::{EventKind, InterestSet};
+            use UpdateKind::*;
 
-        // Anything user-defined observes everything that it can observe.
-        assert(filter_a().chain(filter(|| true)), hashset! { A });
-        assert(user_defined_filter().chain(filter_a()), hashset! { A, B, C });
-        assert(filter_a().chain(user_defined_filter()), hashset! { A });
-        assert(
-            entry().branch(filter_a()).branch(filter_b()).chain(user_defined_filter()),
-            hashset! { A, B, C },
-        );
-        assert(
-            entry()
-                .branch(filter_a().endpoint(|| async {}))
-                .branch(filter_b().endpoint(|| async {})),
-            hashset! { A, B },
-        );
-        assert(user_defined_filter(), hashset! { A, B, C });
-        assert(user_defined_filter().branch(filter_a()), hashset! { A, B, C });
+            #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+            enum UpdateKind {
+                A,
+                B,
+                C,
+            }
 
-        // An entry is "invisible".
-        assert(entry(), hashset! {});
-        assert(entry().chain(filter_a().endpoint(|| async {})), hashset! { A });
-        assert(entry().branch(filter_a()), hashset! {});
+            impl EventKind for UpdateKind {
+                fn full_set() -> HashSet<Self> {
+                    hashset! { A, B, C }
+                }
 
-        // Chained non-overlapping filters do not allow anything.
-        assert(filter_a().chain(filter_b()).endpoint(|| async {}), hashset! {});
-    }
+                fn empty_set() -> HashSet<Self> {
+                    hashset! {}
+                }
+            }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn type_check_success() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
-        #[derive(Clone)]
-        struct C;
+            #[derive(Clone)]
+            #[allow(dead_code)]
+            enum Update {
+                A(i32),
+                B(u8),
+                C(u64),
+            }
 
-        macro_rules! test {
-            ($($key:ty),*) => {
-                type_check(
-                    &HandlerSignature::Other {
-                        obligations: btreemap! {
-                            $(Type::of::<$key>() => Location::caller(),)*
-                        },
-                        guaranteed_outcomes: btreeset! {},
-                        conditional_outcomes: btreeset! {},
-                        continues: true,
+            fn filter_a<Out>() -> Handler<'static, Out, InterestSet<UpdateKind>>
+            where
+                Out: Send + Sync + 'static,
+            {
+                filter_map_with_description(
+                    InterestSet::new_filter(hashset! { A }),
+                    |update: Update| match update {
+                        Update::A(x) => Some(x),
+                        _ => None,
                     },
-                    &deps![A, B, C],
-                    &[],
-                );
-            };
+                )
+            }
+
+            fn filter_b<Out>() -> Handler<'static, Out, InterestSet<UpdateKind>>
+            where
+                Out: Send + Sync + 'static,
+            {
+                filter_map_with_description(
+                    InterestSet::new_filter(hashset! { B }),
+                    |update: Update| match update {
+                        Update::B(x) => Some(x),
+                        _ => None,
+                    },
+                )
+            }
+
+            fn filter_c<Out>() -> Handler<'static, Out, InterestSet<UpdateKind>>
+            where
+                Out: Send + Sync + 'static,
+            {
+                filter_map_with_description(
+                    InterestSet::new_filter(hashset! { C }),
+                    |update: Update| match update {
+                        Update::B(x) => Some(x),
+                        _ => None,
+                    },
+                )
+            }
+
+            // User-defined filter that doesn't provide allowed updates
+            fn user_defined_filter<Out>() -> Handler<'static, Out, InterestSet<UpdateKind>>
+            where
+                Out: Send + Sync + 'static,
+            {
+                filter_map(|update: Update| match update {
+                    Update::B(x) => Some(x),
+                    _ => None,
+                })
+            }
+
+            #[track_caller]
+            fn assert(
+                handler: Handler<'static, (), description::InterestSet<UpdateKind>>,
+                allowed: HashSet<UpdateKind>,
+            ) {
+                assert_eq!(handler.description().observed, allowed);
+            }
+
+            // Filters do not observe anything on their own.
+            assert(filter_a(), hashset! {});
+            assert(entry().chain(filter_b()), hashset! {});
+            assert(filter_a().chain(filter_b()), hashset! {});
+            assert(filter_a().branch(filter_b()), hashset! {});
+            assert(filter_a().branch(filter_b()).branch(filter_c().chain(filter_c())), hashset! {});
+
+            // Anything user-defined observes everything that it can observe.
+            assert(filter_a().chain(filter(|| true)), hashset! { A });
+            assert(user_defined_filter().chain(filter_a()), hashset! { A, B, C });
+            assert(filter_a().chain(user_defined_filter()), hashset! { A });
+            assert(
+                entry().branch(filter_a()).branch(filter_b()).chain(user_defined_filter()),
+                hashset! { A, B, C },
+            );
+            assert(
+                entry()
+                    .branch(filter_a().endpoint(|| async {}))
+                    .branch(filter_b().endpoint(|| async {})),
+                hashset! { A, B },
+            );
+            assert(user_defined_filter(), hashset! { A, B, C });
+            assert(user_defined_filter().branch(filter_a()), hashset! { A, B, C });
+
+            // An entry is "invisible".
+            assert(entry(), hashset! {});
+            assert(entry().chain(filter_a().endpoint(|| async {})), hashset! { A });
+            assert(entry().branch(filter_a()), hashset! {});
+
+            // Chained non-overlapping filters do not allow anything.
+            assert(filter_a().chain(filter_b()).endpoint(|| async {}), hashset! {});
         }
 
-        // Type-checking an entry must succeed.
-        type_check(&HandlerSignature::Entry, &deps![], &[]);
+        async fn type_check_success() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
+            #[derive(Clone)]
+            struct C;
 
-        // Type-checking subsets of provided types must succeed.
-        test!(A, B, C);
-        test!(A, B);
-        test!(A, C);
-        test!(B, C);
-        test!(A);
-        test!(B);
-        test!(C);
-    }
+            macro_rules! test {
+                ($($key:ty),*) => {
+                    type_check(
+                        &HandlerSignature::Other {
+                            obligations: btreemap! {
+                                $(Type::of::<$key>() => Location::caller(),)*
+                            },
+                            guaranteed_outcomes: btreeset! {},
+                            conditional_outcomes: btreeset! {},
+                            continues: true,
+                        },
+                        &deps![A, B, C],
+                        &[],
+                    );
+                };
+            }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[should_panic(expected = "Your handler accepts the following types:
+            // Type-checking an entry must succeed.
+            type_check(&HandlerSignature::Entry, &deps![], &[]);
+
+            // Type-checking subsets of provided types must succeed.
+            test!(A, B, C);
+            test!(A, B);
+            test!(A, C);
+            test!(B, C);
+            test!(A);
+            test!(B);
+            test!(C);
+        }
+
+        #[should_panic(expected = "Your handler accepts the following types:
     `dptree::handler::core::tests::type_check_panic::A`
     `dptree::handler::core::tests::type_check_panic::B`
     `dptree::handler::core::tests::type_check_panic::C`
@@ -985,394 +970,359 @@ The missing values are:
 
 Make sure all the required values are provided to the handler. For more information, visit <https://docs.rs/dptree/latest/dptree>.
 ")]
-    fn type_check_panic() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
-        #[derive(Clone)]
-        struct C;
+        fn type_check_panic() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
+            #[derive(Clone)]
+            struct C;
 
-        type_check(
-            &HandlerSignature::Other {
-                obligations: btreemap! {
-                    Type::of::<A>() => Location::caller(),
-                    Type::of::<B>() => Location::caller(),
-                    Type::of::<C>() => FIXED_LOCATION,
+            type_check(
+                &HandlerSignature::Other {
+                    obligations: btreemap! {
+                        Type::of::<A>() => Location::caller(),
+                        Type::of::<B>() => Location::caller(),
+                        Type::of::<C>() => FIXED_LOCATION,
+                    },
+                    guaranteed_outcomes: btreeset! {},
+                    conditional_outcomes: btreeset! {},
+                    continues: true,
                 },
-                guaranteed_outcomes: btreeset! {},
-                conditional_outcomes: btreeset! {},
-                continues: true,
-            },
-            // `C` is required but not provided.
-            &deps![A, B],
-            &[],
-        );
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    fn type_eq_ord_consistent() {
-        #[derive(Clone)]
-        struct A;
-
-        let ta1 = Type { id: A.type_id(), name: "A1" };
-        let ta2 = Type { id: A.type_id(), name: "A2" };
-
-        assert!(!(ta1 == ta2));
-        assert!(ta1 < ta2);
-        assert!(!(ta1 > ta2));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    fn type_btreeset_not_contains_duplicate_name() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
-
-        let ta = Type { id: A.type_id(), name: "DuplicateName" };
-        let tb = Type { id: B.type_id(), name: "DuplicateName" };
-        let set = btreeset! {ta};
-
-        assert!(ta != tb);
-        assert!(!set.contains(&tb));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn type_infer_check_chained_combinators() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
-        #[derive(Clone)]
-        struct C;
-        #[derive(Clone)]
-        struct D;
-        #[derive(Clone)]
-        struct E;
-        #[derive(Clone)]
-        struct F;
-        #[derive(Clone)]
-        struct G;
-        #[derive(Clone, Debug, Eq, PartialEq)]
-        struct H;
-
-        let h: Handler<H> = entry()
-            .map(|/* In the final input types. */ _: A| B)
-            .inspect(
-                |/* This type must be removed from the final input types because it is
-                  * provided by the `.map` above. */
-                 _: B,
-                 /* This type must "propagate" to the final input types. */
-                 _: E| (),
-            )
-            .filter_map(|/* In the final input types. */ _: C| Some(D))
-            .filter(
-                |/* This type is provided by the `.filter_map` above. */ _: D,
-                 /* Must propagate. */ _: F| true,
-            )
-            .endpoint(
-                /* `B` and `D` are provided at this point. */
-                |_: B, _: D, /* Must propagate. */ _: G| async { H },
+                // `C` is required but not provided.
+                &deps![A, B],
+                &[],
             );
-
-        let input_types =
-            [Type::of::<A>(), Type::of::<C>(), Type::of::<E>(), Type::of::<F>(), Type::of::<G>()];
-        let outcomes = btreeset! {Type::of::<B>(), Type::of::<D>()};
-
-        if let HandlerSignature::Other {
-            obligations: actual_obligations,
-            guaranteed_outcomes: actual_guaranteed_outcomes,
-            conditional_outcomes: actual_conditional_outcomes,
-            continues: _continues,
-        } = h.sig()
-        {
-            assert_eq!(
-                actual_obligations.keys().collect::<Vec<_>>(),
-                input_types.iter().collect::<Vec<_>>()
-            );
-            let all_outcomes = actual_guaranteed_outcomes
-                .union(actual_conditional_outcomes)
-                .cloned()
-                .collect::<BTreeSet<_>>();
-            assert_eq!(all_outcomes, outcomes);
-        } else {
-            panic!("Expected `HandlerSignature::Other`");
         }
 
-        let deps = deps![A, C, E, F, G];
+        fn type_eq_ord_consistent() {
+            #[derive(Clone)]
+            struct A;
 
-        type_check(h.sig(), &deps, &[]);
+            let ta1 = Type { id: A.type_id(), name: "A1" };
+            let ta2 = Type { id: A.type_id(), name: "A2" };
 
-        // Must not panic during execution.
-        assert_eq!(h.dispatch(deps).await, ControlFlow::Break(H));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn type_infer_check_branched_combinators() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
-        #[derive(Clone)]
-        struct C;
-        #[derive(Clone)]
-        struct D;
-        #[derive(Clone)]
-        struct E;
-        #[derive(Clone, Debug, Eq, PartialEq)]
-        struct F;
-
-        let h: Handler<F> = entry()
-            .branch(
-                crate::inspect(|_: A| ()).map(|| B).map(|| C).map(|| D).endpoint(|| async { F }),
-            )
-            .branch(crate::inspect(|_: E| ()).map(|| B).map(|| D).endpoint(|| async { F }));
-
-        // The union of the input types of both branches.
-        let input_types = btreeset! {Type::of::<A>(), Type::of::<E>()};
-        // Both branches provide different guaranteed outcomes.
-        let output_types = btreeset! {Type::of::<B>(), Type::of::<C>(), Type::of::<D>()};
-
-        if let HandlerSignature::Other {
-            obligations: actual_obligations,
-            guaranteed_outcomes: actual_guaranteed_outcomes,
-            conditional_outcomes: actual_conditional_outcomes,
-            continues: _continues,
-        } = h.sig()
-        {
-            assert_eq!(
-                actual_obligations.keys().collect::<Vec<_>>(),
-                input_types.iter().collect::<Vec<_>>()
-            );
-            let all_outcomes = actual_guaranteed_outcomes
-                .union(actual_conditional_outcomes)
-                .cloned()
-                .collect::<BTreeSet<_>>();
-            assert_eq!(all_outcomes, output_types);
-        } else {
-            panic!("Expected `HandlerSignature::Other`");
+            assert!(!(ta1 == ta2));
+            assert!(ta1 < ta2);
+            assert!(!(ta1 > ta2));
         }
 
-        let deps = deps![A, E];
+        fn type_btreeset_not_contains_duplicate_name() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
 
-        type_check(h.sig(), &deps, &[]);
+            let ta = Type { id: A.type_id(), name: "DuplicateName" };
+            let tb = Type { id: B.type_id(), name: "DuplicateName" };
+            let set = btreeset! {ta};
 
-        // Must not panic during execution.
-        assert_eq!(h.dispatch(deps).await, ControlFlow::Break(F));
-    }
+            assert!(ta != tb);
+            assert!(!set.contains(&tb));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn obligations_priority() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
-        #[derive(Clone, Debug, Eq, PartialEq)]
-        struct C;
+        async fn type_infer_check_chained_combinators() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
+            #[derive(Clone)]
+            struct C;
+            #[derive(Clone)]
+            struct D;
+            #[derive(Clone)]
+            struct E;
+            #[derive(Clone)]
+            struct F;
+            #[derive(Clone)]
+            struct G;
+            #[derive(Clone, Debug, Eq, PartialEq)]
+            struct H;
 
-        fn test<T: 'static>(h: Handler<C>, column: u32) {
+            let h: Handler<H> = entry()
+                .map(|/* In the final input types. */ _: A| B)
+                .inspect(
+                    |/* This type must be removed from the final input types because it is
+                    * provided by the `.map` above. */
+                    _: B,
+                    /* This type must "propagate" to the final input types. */
+                    _: E| (),
+                )
+                .filter_map(|/* In the final input types. */ _: C| Some(D))
+                .filter(
+                    |/* This type is provided by the `.filter_map` above. */ _: D,
+                    /* Must propagate. */ _: F| true,
+                )
+                .endpoint(
+                    /* `B` and `D` are provided at this point. */
+                    |_: B, _: D, /* Must propagate. */ _: G| async { H },
+                );
+
+            let input_types =
+                [Type::of::<A>(), Type::of::<C>(), Type::of::<E>(), Type::of::<F>(), Type::of::<G>()];
+            let outcomes = btreeset! {Type::of::<B>(), Type::of::<D>()};
+
             if let HandlerSignature::Other {
-                obligations,
-                guaranteed_outcomes: _,
-                conditional_outcomes: _,
-                continues: _,
+                obligations: actual_obligations,
+                guaranteed_outcomes: actual_guaranteed_outcomes,
+                conditional_outcomes: actual_conditional_outcomes,
+                continues: _continues,
             } = h.sig()
             {
-                let (_ty, &location) = obligations
-                    .iter()
-                    .find(|(ty, _location)| ty.id == TypeId::of::<T>())
-                    .expect("Missing obligation");
-                assert_eq!(location.column(), column);
+                assert_eq!(
+                    actual_obligations.keys().collect::<Vec<_>>(),
+                    input_types.iter().collect::<Vec<_>>()
+                );
+                let all_outcomes = actual_guaranteed_outcomes
+                    .union(actual_conditional_outcomes)
+                    .cloned()
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(all_outcomes, outcomes);
             } else {
                 panic!("Expected `HandlerSignature::Other`");
             }
+
+            let deps = deps![A, C, E, F, G];
+
+            type_check(h.sig(), &deps, &[]);
+
+            // Must not panic during execution.
+            assert_eq!(h.dispatch(deps).await, ControlFlow::Break(H));
         }
 
-        #[rustfmt::skip]
-        let h: Handler<C> = entry().map(|_: A| ()).endpoint(|_: A, _: B| async { C });
-        test::<A>(h, 37);
+        async fn type_infer_check_branched_combinators() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
+            #[derive(Clone)]
+            struct C;
+            #[derive(Clone)]
+            struct D;
+            #[derive(Clone)]
+            struct E;
+            #[derive(Clone, Debug, Eq, PartialEq)]
+            struct F;
 
-        #[rustfmt::skip]
-        let h: Handler<C> =
-            entry().branch(crate::map(|_: A|  { C })).branch(endpoint(|_: A, _: B| async { C }));
-        test::<A>(h, 28);
-    }
+            let h: Handler<F> = entry()
+                .branch(
+                    crate::inspect(|_: A| ()).map(|| B).map(|| C).map(|| D).endpoint(|| async { F }),
+                )
+                .branch(crate::inspect(|_: E| ()).map(|| B).map(|| D).endpoint(|| async { F }));
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[should_panic(expected = "Ill-typed handler chain: the second handler cannot be an entry")]
-    fn chain_entry() {
-        let _: Handler<()> = entry().chain(entry());
-    }
+            // The union of the input types of both branches.
+            let input_types = btreeset! {Type::of::<A>(), Type::of::<E>()};
+            // Both branches provide different guaranteed outcomes.
+            let output_types = btreeset! {Type::of::<B>(), Type::of::<C>(), Type::of::<D>()};
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[should_panic(expected = "Ill-typed handler branch: the second handler cannot be an entry")]
-    fn branch_entry() {
-        let _: Handler<()> = entry().branch(entry());
-    }
+            if let HandlerSignature::Other {
+                obligations: actual_obligations,
+                guaranteed_outcomes: actual_guaranteed_outcomes,
+                conditional_outcomes: actual_conditional_outcomes,
+                continues: _continues,
+            } = h.sig()
+            {
+                assert_eq!(
+                    actual_obligations.keys().collect::<Vec<_>>(),
+                    input_types.iter().collect::<Vec<_>>()
+                );
+                let all_outcomes = actual_guaranteed_outcomes
+                    .union(actual_conditional_outcomes)
+                    .cloned()
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(all_outcomes, output_types);
+            } else {
+                panic!("Expected `HandlerSignature::Other`");
+            }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn chain_branch_type_check() {
-        #[derive(Clone)]
-        struct A;
+            let deps = deps![A, E];
 
-        let handler: Handler<()> =
-            entry().chain(crate::map(|| A)).branch(endpoint(|_: A| async {}));
+            type_check(h.sig(), &deps, &[]);
 
-        let _no_panic_here: ControlFlow<(), _> = handler.dispatch(deps![]).await;
+            // Must not panic during execution.
+            assert_eq!(h.dispatch(deps).await, ControlFlow::Break(F));
+        }
 
-        type_check(handler.sig(), &deps![], &[]);
-    }
+        async fn obligations_priority() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
+            #[derive(Clone, Debug, Eq, PartialEq)]
+            struct C;
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn guaranteed_outcomes_chain_success() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
+            fn test<T: 'static>(h: Handler<C>, column: u32) {
+                if let HandlerSignature::Other {
+                    obligations,
+                    guaranteed_outcomes: _,
+                    conditional_outcomes: _,
+                    continues: _,
+                } = h.sig()
+                {
+                    let (_ty, &location) = obligations
+                        .iter()
+                        .find(|(ty, _location)| ty.id == TypeId::of::<T>())
+                        .expect("Missing obligation");
+                    assert_eq!(location.column(), column);
+                } else {
+                    panic!("Expected `HandlerSignature::Other`");
+                }
+            }
 
-        let handler: Handler<()> = entry().map(|| A).map(|_: A| B).endpoint(|_: B| async {});
+            #[rustfmt::skip]
+            let h: Handler<C> = entry().map(|_: A| ()).endpoint(|_: A, _: B| async { C });
+            test::<A>(h, 41);
 
-        let result = handler.dispatch(deps![]).await;
-        assert_eq!(result, ControlFlow::Break(()));
+            #[rustfmt::skip]
+            let h: Handler<C> =
+                entry().branch(crate::map(|_: A|  { C })).branch(endpoint(|_: A, _: B| async { C }));
+            test::<A>(h, 32);
+        }
 
-        type_check(handler.sig(), &deps![], &[]);
-    }
+        #[should_panic(expected = "Ill-typed handler chain: the second handler cannot be an entry")]
+        fn chain_entry() {
+            let _: Handler<()> = entry().chain(entry());
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn conditional_outcomes_chain_success() {
-        #[derive(Clone)]
-        struct A;
+        #[should_panic(expected = "Ill-typed handler branch: the second handler cannot be an entry")]
+        fn branch_entry() {
+            let _: Handler<()> = entry().branch(entry());
+        }
 
-        let handler: Handler<()> = entry().filter_map(|| Some(A)).endpoint(|_: A| async {});
+        async fn chain_branch_type_check() {
+            #[derive(Clone)]
+            struct A;
 
-        let result = handler.dispatch(deps![]).await;
-        assert_eq!(result, ControlFlow::Break(()));
+            let handler: Handler<()> =
+                entry().chain(crate::map(|| A)).branch(endpoint(|_: A| async {}));
 
-        type_check(handler.sig(), &deps![], &[]);
-    }
+            let _no_panic_here: ControlFlow<(), _> = handler.dispatch(deps![]).await;
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn guaranteed_outcomes_branch_success() {
-        #[derive(Clone)]
-        struct A;
+            type_check(handler.sig(), &deps![], &[]);
+        }
 
-        let producer = entry().map(|| A);
+        async fn guaranteed_outcomes_chain_success() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
 
-        // In branch context, guaranteed outcomes can satisfy obligations.
-        let handler: Handler<()> = producer.branch(endpoint(|_: A| async {}));
+            let handler: Handler<()> = entry().map(|| A).map(|_: A| B).endpoint(|_: B| async {});
 
-        let result = handler.dispatch(deps![]).await;
-        assert_eq!(result, ControlFlow::Break(()));
+            let result = handler.dispatch(deps![]).await;
+            assert_eq!(result, ControlFlow::Break(()));
 
-        type_check(handler.sig(), &deps![], &[]);
-    }
+            type_check(handler.sig(), &deps![], &[]);
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn mixed_outcomes_chain() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
-        #[derive(Clone)]
-        struct C;
+        async fn conditional_outcomes_chain_success() {
+            #[derive(Clone)]
+            struct A;
 
-        let handler: Handler<()> = entry()
-            .map(|| A) // guaranteed
-            .filter_map(|_: A| Some(B)) // conditional, but `A` is guaranteed
-            .map(|_: B| C) // guaranteed, but `B` is conditional
-            .endpoint(|_: C| async {}); // consumes `C`
+            let handler: Handler<()> = entry().filter_map(|| Some(A)).endpoint(|_: A| async {});
 
-        let result = handler.dispatch(deps![]).await;
-        assert_eq!(result, ControlFlow::Break(()));
+            let result = handler.dispatch(deps![]).await;
+            assert_eq!(result, ControlFlow::Break(()));
 
-        type_check(handler.sig(), &deps![], &[]);
-    }
+            type_check(handler.sig(), &deps![], &[]);
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn branch_with_guaranteed_continuation() {
-        #[derive(Clone)]
-        struct A;
+        async fn guaranteed_outcomes_branch_success() {
+            #[derive(Clone)]
+            struct A;
 
-        // The first branch produces `A` and continues (`map` always continues).
-        let first_branch = entry().map(|| A).inspect(|_: A| ()); // `inspect` continues, keeping `A` available
+            let producer = entry().map(|| A);
 
-        // The second branch can use `A`, because the first branch guarantees it and
-        // continues the execution.
-        let handler: Handler<()> = first_branch.branch(endpoint(|_: A| async {}));
+            // In branch context, guaranteed outcomes can satisfy obligations.
+            let handler: Handler<()> = producer.branch(endpoint(|_: A| async {}));
 
-        let result = handler.dispatch(deps![]).await;
-        assert_eq!(result, ControlFlow::Break(()));
+            let result = handler.dispatch(deps![]).await;
+            assert_eq!(result, ControlFlow::Break(()));
 
-        type_check(handler.sig(), &deps![], &[]);
-    }
+            type_check(handler.sig(), &deps![], &[]);
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[should_panic(expected = "Your handler accepts the following types:")]
-    async fn deeply_nested_conditional_failure() {
-        #[derive(Clone)]
-        struct A;
-        #[derive(Clone)]
-        struct B;
+        async fn mixed_outcomes_chain() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
+            #[derive(Clone)]
+            struct C;
 
-        // Deep nesting where conditional outcome propagation should fail.
-        let handler: Handler<()> = entry()
-            .branch(
-                entry()
-                    .branch(crate::filter_map(|| Some(A)).endpoint(|| async {}))
-                    .branch(crate::filter_map(|_: A| Some(B)).endpoint(|| async {})),
-            )
-            .branch(endpoint(|_: B| async {})); // `B` is not guaranteed to be available
+            let handler: Handler<()> = entry()
+                .map(|| A) // guaranteed
+                .filter_map(|_: A| Some(B)) // conditional, but `A` is guaranteed
+                .map(|_: B| C) // guaranteed, but `B` is conditional
+                .endpoint(|_: C| async {}); // consumes `C`
 
-        type_check(handler.sig(), &deps![], &[]);
-    }
+            let result = handler.dispatch(deps![]).await;
+            assert_eq!(result, ControlFlow::Break(()));
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
-                               second handler will never be called.")]
-    fn chain_endpoint_with_handler() {
-        let _: Handler<()> = endpoint(|| async {}).endpoint(|| async {});
-    }
+            type_check(handler.sig(), &deps![], &[]);
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
-                               second handler will never be called.")]
-    fn chain_endpoint_with_filter() {
-        let _: Handler<()> = endpoint(|| async {}).filter(|_: i32| true);
-    }
+        async fn branch_with_guaranteed_continuation() {
+            #[derive(Clone)]
+            struct A;
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
-                               second handler will never be called.")]
-    fn chain_endpoint_with_map() {
-        let _: Handler<()> = endpoint(|| async {}).map(|| 42);
-    }
+            // The first branch produces `A` and continues (`map` always continues).
+            let first_branch = entry().map(|| A).inspect(|_: A| ()); // `inspect` continues, keeping `A` available
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
-                               second handler will never be called.")]
-    fn chain_complex_endpoint_dead_code() {
-        let _: Handler<()> = entry()
-            .chain(filter(|x: i32| x > 0))
-            .chain(endpoint(|| async {}))
-            .chain(crate::map(|| "Unreachable"));
+            // The second branch can use `A`, because the first branch guarantees it and
+            // continues the execution.
+            let handler: Handler<()> = first_branch.branch(endpoint(|_: A| async {}));
+
+            let result = handler.dispatch(deps![]).await;
+            assert_eq!(result, ControlFlow::Break(()));
+
+            type_check(handler.sig(), &deps![], &[]);
+        }
+
+        #[should_panic(expected = "Your handler accepts the following types:")]
+        async fn deeply_nested_conditional_failure() {
+            #[derive(Clone)]
+            struct A;
+            #[derive(Clone)]
+            struct B;
+
+            // Deep nesting where conditional outcome propagation should fail.
+            let handler: Handler<()> = entry()
+                .branch(
+                    entry()
+                        .branch(crate::filter_map(|| Some(A)).endpoint(|| async {}))
+                        .branch(crate::filter_map(|_: A| Some(B)).endpoint(|| async {})),
+                )
+                .branch(endpoint(|_: B| async {})); // `B` is not guaranteed to be available
+
+            type_check(handler.sig(), &deps![], &[]);
+        }
+
+        #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
+                                second handler will never be called.")]
+        fn chain_endpoint_with_handler() {
+            let _: Handler<()> = endpoint(|| async {}).endpoint(|| async {});
+        }
+
+        #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
+                                second handler will never be called.")]
+        fn chain_endpoint_with_filter() {
+            let _: Handler<()> = endpoint(|| async {}).filter(|_: i32| true);
+        }
+
+        #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
+                                second handler will never be called.")]
+        fn chain_endpoint_with_map() {
+            let _: Handler<()> = endpoint(|| async {}).map(|| 42);
+        }
+
+        #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
+                                second handler will never be called.")]
+        fn chain_complex_endpoint_dead_code() {
+            let _: Handler<()> = entry()
+                .chain(filter(|x: i32| x > 0))
+                .chain(endpoint(|| async {}))
+                .chain(crate::map(|| "Unreachable"));
+        }
     }
 }

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -124,15 +124,11 @@ impl Hash for Type {
     }
 }
 
-type DynFn<'a, Output> = DynFnInner<'a, Output>;
-
-/// See [`DynFn`] (kept as a type alias so `Send`/`Sync` can be dropped on wasm).
 #[cfg(not(target_arch = "wasm32"))]
-type DynFnInner<'a, Output> =
+type DynFn<'a, Output> =
     dyn Fn(DependencyMap, Cont<'a, Output>) -> HandlerResult<'a, Output> + Send + Sync + 'a;
 #[cfg(target_arch = "wasm32")]
-type DynFnInner<'a, Output> =
-    dyn Fn(DependencyMap, Cont<'a, Output>) -> HandlerResult<'a, Output> + 'a;
+type DynFn<'a, Output> = dyn Fn(DependencyMap, Cont<'a, Output>) -> HandlerResult<'a, Output> + 'a;
 
 /// A continuation representing the rest of a handler chain.
 pub type Cont<'a, Output> = ContInner<'a, Output>;
@@ -172,7 +168,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// # #[tokio::main]
+    /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
     /// use dptree::prelude::*;
     ///
@@ -308,7 +304,7 @@ where
     /// ```
     /// use dptree::prelude::*;
     ///
-    /// # #[tokio::main]
+    /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
     ///
     /// #[derive(Debug, PartialEq)]
@@ -431,7 +427,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// # #[tokio::main]
+    /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
     /// use dptree::prelude::*;
     ///
@@ -659,6 +655,7 @@ pub(crate) fn help_inference<Output>(h: Handler<Output>) -> Handler<Output> {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     use crate::{
@@ -670,7 +667,8 @@ mod tests {
 
     use maplit::{btreemap, btreeset, hashset};
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_from_fn_break() {
         let input = 123;
         let output = "ABC";
@@ -698,7 +696,8 @@ mod tests {
         assert!(result == ControlFlow::Break(output));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_from_fn_continue() {
         let input = 123;
         type Output = &'static str;
@@ -726,7 +725,8 @@ mod tests {
         assert!(result == ControlFlow::Continue(deps![input]));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_entry() {
         let input = 123;
         type Output = &'static str;
@@ -736,7 +736,8 @@ mod tests {
         assert!(result == ControlFlow::Continue(deps![input]));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_execute() {
         let input = 123;
         let output = "ABC";
@@ -767,7 +768,8 @@ mod tests {
         assert!(result == ControlFlow::Break(output));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_deeply_nested_tree() {
         #[derive(Debug, PartialEq)]
         enum Output {
@@ -807,7 +809,8 @@ mod tests {
         assert_eq!(dispatcher.dispatch(deps![-2]).await, ControlFlow::Break(Output::LT));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn allowed_updates() {
         use crate::description::{EventKind, InterestSet};
         use UpdateKind::*;
@@ -928,7 +931,8 @@ mod tests {
         assert(filter_a().chain(filter_b()).endpoint(|| async {}), hashset! {});
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn type_check_success() {
         #[derive(Clone)]
         struct A;
@@ -967,7 +971,8 @@ mod tests {
         test!(C);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[should_panic(expected = "Your handler accepts the following types:
     `dptree::handler::core::tests::type_check_panic::A`
     `dptree::handler::core::tests::type_check_panic::B`
@@ -1005,7 +1010,8 @@ Make sure all the required values are provided to the handler. For more informat
         );
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn type_eq_ord_consistent() {
         #[derive(Clone)]
         struct A;
@@ -1018,7 +1024,8 @@ Make sure all the required values are provided to the handler. For more informat
         assert!(!(ta1 > ta2));
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn type_btreeset_not_contains_duplicate_name() {
         #[derive(Clone)]
         struct A;
@@ -1033,7 +1040,8 @@ Make sure all the required values are provided to the handler. For more informat
         assert!(!set.contains(&tb));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn type_infer_check_chained_combinators() {
         #[derive(Clone)]
         struct A;
@@ -1103,7 +1111,8 @@ Make sure all the required values are provided to the handler. For more informat
         assert_eq!(h.dispatch(deps).await, ControlFlow::Break(H));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn type_infer_check_branched_combinators() {
         #[derive(Clone)]
         struct A;
@@ -1157,7 +1166,8 @@ Make sure all the required values are provided to the handler. For more informat
         assert_eq!(h.dispatch(deps).await, ControlFlow::Break(F));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn obligations_priority() {
         #[derive(Clone)]
         struct A;
@@ -1194,19 +1204,22 @@ Make sure all the required values are provided to the handler. For more informat
         test::<A>(h, 28);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[should_panic(expected = "Ill-typed handler chain: the second handler cannot be an entry")]
     fn chain_entry() {
         let _: Handler<()> = entry().chain(entry());
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[should_panic(expected = "Ill-typed handler branch: the second handler cannot be an entry")]
     fn branch_entry() {
         let _: Handler<()> = entry().branch(entry());
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn chain_branch_type_check() {
         #[derive(Clone)]
         struct A;
@@ -1219,7 +1232,8 @@ Make sure all the required values are provided to the handler. For more informat
         type_check(handler.sig(), &deps![], &[]);
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn guaranteed_outcomes_chain_success() {
         #[derive(Clone)]
         struct A;
@@ -1234,7 +1248,8 @@ Make sure all the required values are provided to the handler. For more informat
         type_check(handler.sig(), &deps![], &[]);
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn conditional_outcomes_chain_success() {
         #[derive(Clone)]
         struct A;
@@ -1247,7 +1262,8 @@ Make sure all the required values are provided to the handler. For more informat
         type_check(handler.sig(), &deps![], &[]);
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn guaranteed_outcomes_branch_success() {
         #[derive(Clone)]
         struct A;
@@ -1263,7 +1279,8 @@ Make sure all the required values are provided to the handler. For more informat
         type_check(handler.sig(), &deps![], &[]);
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn mixed_outcomes_chain() {
         #[derive(Clone)]
         struct A;
@@ -1284,7 +1301,8 @@ Make sure all the required values are provided to the handler. For more informat
         type_check(handler.sig(), &deps![], &[]);
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn branch_with_guaranteed_continuation() {
         #[derive(Clone)]
         struct A;
@@ -1302,7 +1320,8 @@ Make sure all the required values are provided to the handler. For more informat
         type_check(handler.sig(), &deps![], &[]);
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[should_panic(expected = "Your handler accepts the following types:")]
     async fn deeply_nested_conditional_failure() {
         #[derive(Clone)]
@@ -1322,28 +1341,32 @@ Make sure all the required values are provided to the handler. For more informat
         type_check(handler.sig(), &deps![], &[]);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
                                second handler will never be called.")]
     fn chain_endpoint_with_handler() {
         let _: Handler<()> = endpoint(|| async {}).endpoint(|| async {});
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
                                second handler will never be called.")]
     fn chain_endpoint_with_filter() {
         let _: Handler<()> = endpoint(|| async {}).filter(|_: i32| true);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
                                second handler will never be called.")]
     fn chain_endpoint_with_map() {
         let _: Handler<()> = endpoint(|| async {}).map(|| 42);
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[should_panic(expected = "Dead code detected: since the first handler aborts execution, the \
                                second handler will never be called.")]
     fn chain_complex_endpoint_dead_code() {

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -3,7 +3,12 @@
 #[cfg(test)]
 const FIXED_LOCATION: &Location = Location::caller();
 
-use crate::{description, prelude::DependencyMap, HandlerDescription};
+use crate::{
+    description,
+    prelude::DependencyMap,
+    send::{BoxFuture, MaybeSend, MaybeSync},
+    HandlerDescription,
+};
 
 use std::{
     any::TypeId,
@@ -17,7 +22,6 @@ use std::{
 };
 
 use colored::Colorize;
-use futures::future::BoxFuture;
 
 /// An instance that receives an input and decides whether to break a chain or
 /// pass the value further.
@@ -120,12 +124,23 @@ impl Hash for Type {
     }
 }
 
-type DynFn<'a, Output> =
+type DynFn<'a, Output> = DynFnInner<'a, Output>;
+
+/// See [`DynFn`] (kept as a type alias so `Send`/`Sync` can be dropped on wasm).
+#[cfg(not(target_arch = "wasm32"))]
+type DynFnInner<'a, Output> =
     dyn Fn(DependencyMap, Cont<'a, Output>) -> HandlerResult<'a, Output> + Send + Sync + 'a;
+#[cfg(target_arch = "wasm32")]
+type DynFnInner<'a, Output> =
+    dyn Fn(DependencyMap, Cont<'a, Output>) -> HandlerResult<'a, Output> + 'a;
 
 /// A continuation representing the rest of a handler chain.
-pub type Cont<'a, Output> =
+pub type Cont<'a, Output> = ContInner<'a, Output>;
+#[cfg(not(target_arch = "wasm32"))]
+type ContInner<'a, Output> =
     Box<dyn FnOnce(DependencyMap) -> HandlerResult<'a, Output> + Send + Sync + 'a>;
+#[cfg(target_arch = "wasm32")]
+type ContInner<'a, Output> = Box<dyn FnOnce(DependencyMap) -> HandlerResult<'a, Output> + 'a>;
 
 /// An output type produced by a handler.
 pub type HandlerResult<'a, Output> = BoxFuture<'a, ControlFlow<Output, DependencyMap>>;
@@ -321,7 +336,7 @@ where
     #[track_caller]
     pub fn branch(self, next: Self) -> Self
     where
-        Output: Send,
+        Output: MaybeSend,
     {
         let required_update_kinds_set = self.description().merge_branch(next.description());
 
@@ -434,8 +449,8 @@ where
     ) -> ControlFlow<Output, DependencyMap>
     where
         Cont: FnOnce(DependencyMap) -> ContFut,
-        Cont: Send + Sync + 'a,
-        ContFut: Future<Output = ControlFlow<Output, DependencyMap>> + Send + 'a,
+        Cont: MaybeSend + MaybeSync + 'a,
+        ContFut: Future<Output = ControlFlow<Output, DependencyMap>> + MaybeSend + 'a,
     {
         (self.data.f)(input, Box::new(|event| Box::pin(cont(event)))).await
     }
@@ -504,8 +519,8 @@ impl Type {
 pub fn from_fn<'a, F, Fut, Output, Descr>(f: F, sig: HandlerSignature) -> Handler<'a, Output, Descr>
 where
     F: Fn(DependencyMap, Cont<'a, Output>) -> Fut,
-    F: Send + Sync + 'a,
-    Fut: Future<Output = ControlFlow<Output, DependencyMap>> + Send + 'a,
+    F: MaybeSend + MaybeSync + 'a,
+    Fut: Future<Output = ControlFlow<Output, DependencyMap>> + MaybeSend + 'a,
     Descr: HandlerDescription,
 {
     from_fn_with_description(Descr::user_defined(), f, sig)
@@ -520,8 +535,8 @@ pub fn from_fn_with_description<'a, F, Fut, Output, Descr>(
 ) -> Handler<'a, Output, Descr>
 where
     F: Fn(DependencyMap, Cont<'a, Output>) -> Fut,
-    F: Send + Sync + 'a,
-    Fut: Future<Output = ControlFlow<Output, DependencyMap>> + Send + 'a,
+    F: MaybeSend + MaybeSync + 'a,
+    Fut: Future<Output = ControlFlow<Output, DependencyMap>> + MaybeSend + 'a,
 {
     Handler {
         data: Arc::new(HandlerData {
@@ -627,13 +642,7 @@ pub fn type_check(sig: &HandlerSignature, container: &DependencyMap, assumptions
                         missing_types_msg.red().bold().to_string()
                     },
                     print_types(
-                        obligations.iter().filter_map(|(ty, _location)| {
-                            if !container_types.contains(ty) {
-                                Some(ty)
-                            } else {
-                                None
-                            }
-                        }),
+                        obligations.keys().filter(|ty| !container_types.contains(ty)),
                         |ty| { format!("`{}` from {}", ty.name, obligations[ty]) },
                     ),
                     note_msg,

--- a/src/handler/description.rs
+++ b/src/handler/description.rs
@@ -3,6 +3,8 @@
 mod interest_set;
 mod unspecified;
 
+use crate::send::{MaybeSend, MaybeSync};
+
 pub use interest_set::{EventKind, InterestSet};
 pub use unspecified::Unspecified;
 
@@ -56,7 +58,7 @@ pub use unspecified::Unspecified;
 ///         .branch(dptree::inspect(|| ())),
 /// );
 /// ```
-pub trait HandlerDescription: Sized + Send + Sync + 'static {
+pub trait HandlerDescription: Sized + MaybeSend + MaybeSync + 'static {
     /// Description for [`entry`](crate::entry).
     fn entry() -> Self;
 

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -51,23 +51,23 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_endpoint() {
-        let input = 123;
-        let output = 7;
+    crate::cross_test! {
+        async fn test_endpoint() {
+            let input = 123;
+            let output = 7;
 
-        let result = help_inference(endpoint(move |num: i32| async move {
-            assert_eq!(num, input);
-            output
-        }))
-        .dispatch(deps![input])
-        .await;
+            let result = help_inference(endpoint(move |num: i32| async move {
+                assert_eq!(num, input);
+                output
+            }))
+            .dispatch(deps![input])
+            .await;
 
-        let result = match result {
-            ControlFlow::Break(b) => b,
-            _ => panic!("Unexpected: handler return ControlFlow::Break"),
-        };
-        assert_eq!(result, output);
+            let result = match result {
+                ControlFlow::Break(b) => b,
+                _ => panic!("Unexpected: handler return ControlFlow::Break"),
+            };
+            assert_eq!(result, output);
+        }
     }
 }

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -51,7 +51,8 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_endpoint() {
         let input = 123;
         let output = 7;

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -1,6 +1,9 @@
 use crate::{
-    description, di::Injectable, from_fn_with_description, Handler, HandlerDescription,
-    HandlerSignature,
+    description,
+    di::Injectable,
+    from_fn_with_description,
+    send::{MaybeSend, MaybeSync},
+    Handler, HandlerDescription, HandlerSignature,
 };
 
 use std::{collections::BTreeSet, ops::ControlFlow, sync::Arc};
@@ -16,7 +19,7 @@ use futures::FutureExt;
 #[track_caller]
 pub fn endpoint<'a, F, Output, FnArgs, Descr>(f: F) -> Endpoint<'a, Output, Descr>
 where
-    F: Injectable<Output, FnArgs> + Send + Sync + 'a,
+    F: Injectable<Output, FnArgs> + MaybeSend + MaybeSync + 'a,
     Output: 'static,
     Descr: HandlerDescription,
 {

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -94,7 +94,8 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_filter() {
         let input_value = 123;
         let input = deps![input_value];
@@ -114,7 +115,8 @@ mod tests {
         assert!(result == ControlFlow::Break(output));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_and_then_filter() {
         let input = 123;
         let output = 7;

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -2,6 +2,7 @@ use crate::{
     di::{Asyncify, Injectable},
     from_fn_with_description,
     handler::core::Handler,
+    send::{MaybeSend, MaybeSync},
     HandlerDescription, HandlerSignature,
 };
 
@@ -16,7 +17,7 @@ use std::{collections::BTreeSet, ops::ControlFlow, sync::Arc};
 #[track_caller]
 pub fn filter<'a, Pred, Output, FnArgs, Descr>(pred: Pred) -> Handler<'a, Output, Descr>
 where
-    Asyncify<Pred>: Injectable<bool, FnArgs> + Send + Sync + 'a,
+    Asyncify<Pred>: Injectable<bool, FnArgs> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
@@ -28,7 +29,7 @@ where
 #[track_caller]
 pub fn filter_async<'a, Pred, Output, FnArgs, Descr>(pred: Pred) -> Handler<'a, Output, Descr>
 where
-    Pred: Injectable<bool, FnArgs> + Send + Sync + 'a,
+    Pred: Injectable<bool, FnArgs> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
@@ -43,7 +44,7 @@ pub fn filter_with_description<'a, Pred, Output, FnArgs, Descr>(
     pred: Pred,
 ) -> Handler<'a, Output, Descr>
 where
-    Asyncify<Pred>: Injectable<bool, FnArgs> + Send + Sync + 'a,
+    Asyncify<Pred>: Injectable<bool, FnArgs> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
 {
     filter_async_with_description(description, Asyncify(pred))
@@ -57,7 +58,7 @@ pub fn filter_async_with_description<'a, Pred, Output, FnArgs, Descr>(
     pred: Pred,
 ) -> Handler<'a, Output, Descr>
 where
-    Pred: Injectable<bool, FnArgs> + Send + Sync + 'a,
+    Pred: Injectable<bool, FnArgs> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
 {
     let pred = Arc::new(pred);

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -94,50 +94,48 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_filter() {
-        let input_value = 123;
-        let input = deps![input_value];
-        let output = 7;
+    crate::cross_test! {
+        async fn test_filter() {
+            let input_value = 123;
+            let input = deps![input_value];
+            let output = 7;
 
-        let result = help_inference(filter_async(move |event: i32| async move {
-            assert_eq!(event, input_value);
-            true
-        }))
-        .endpoint(move |event: i32| async move {
-            assert_eq!(event, input_value);
-            output
-        })
-        .dispatch(input)
-        .await;
+            let result = help_inference(filter_async(move |event: i32| async move {
+                assert_eq!(event, input_value);
+                true
+            }))
+            .endpoint(move |event: i32| async move {
+                assert_eq!(event, input_value);
+                output
+            })
+            .dispatch(input)
+            .await;
 
-        assert!(result == ControlFlow::Break(output));
-    }
+            assert!(result == ControlFlow::Break(output));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_and_then_filter() {
-        let input = 123;
-        let output = 7;
+        async fn test_and_then_filter() {
+            let input = 123;
+            let output = 7;
 
-        let result = help_inference(filter(move |event: i32| {
-            assert_eq!(event, input);
-            true
-        }))
-        .chain(
-            filter_async(move |event: i32| async move {
+            let result = help_inference(filter(move |event: i32| {
                 assert_eq!(event, input);
                 true
-            })
-            .endpoint(move |event: i32| async move {
-                assert_eq!(event, input);
-                output
-            }),
-        )
-        .dispatch(deps![input])
-        .await;
+            }))
+            .chain(
+                filter_async(move |event: i32| async move {
+                    assert_eq!(event, input);
+                    true
+                })
+                .endpoint(move |event: i32| async move {
+                    assert_eq!(event, input);
+                    output
+                }),
+            )
+            .dispatch(deps![input])
+            .await;
 
-        assert!(result == ControlFlow::Break(output));
+            assert!(result == ControlFlow::Break(output));
+        }
     }
 }

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -108,30 +108,28 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_some() {
-        let value = 123;
+    crate::cross_test! {
+        async fn test_some() {
+            let value = 123;
 
-        let result = help_inference(filter_map(move || Some(value)))
-            .endpoint(move |event: i32| async move {
-                assert_eq!(event, value);
-                value
-            })
-            .dispatch(deps![])
-            .await;
+            let result = help_inference(filter_map(move || Some(value)))
+                .endpoint(move |event: i32| async move {
+                    assert_eq!(event, value);
+                    value
+                })
+                .dispatch(deps![])
+                .await;
 
-        assert!(result == ControlFlow::Break(value));
-    }
+            assert!(result == ControlFlow::Break(value));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_none() {
-        let result = help_inference(filter_map(|| None::<i32>))
-            .endpoint(|| async move { unreachable!() })
-            .dispatch(deps![])
-            .await;
+        async fn test_none() {
+            let result = help_inference(filter_map(|| None::<i32>))
+                .endpoint(|| async move { unreachable!() })
+                .dispatch(deps![])
+                .await;
 
-        assert!(result == ControlFlow::Continue(crate::deps![]));
+            assert!(result == ControlFlow::Continue(crate::deps![]));
+        }
     }
 }

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -108,7 +108,8 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_some() {
         let value = 123;
 
@@ -123,7 +124,8 @@ mod tests {
         assert!(result == ControlFlow::Break(value));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_none() {
         let result = help_inference(filter_map(|| None::<i32>))
             .endpoint(|| async move { unreachable!() })

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -1,6 +1,8 @@
 use crate::{
     di::{Asyncify, Injectable},
-    from_fn_with_description, Handler, HandlerDescription, HandlerSignature, Type,
+    from_fn_with_description,
+    send::{MaybeSend, MaybeSync},
+    Handler, HandlerDescription, HandlerSignature, Type,
 };
 
 use std::{collections::BTreeSet, iter::FromIterator, ops::ControlFlow, sync::Arc};
@@ -17,7 +19,7 @@ pub fn filter_map<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
 ) -> Handler<'a, Output, Descr>
 where
-    Asyncify<Projection>: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
+    Asyncify<Projection>: Injectable<Option<NewType>, Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
     NewType: Send + Sync + 'static,
@@ -32,7 +34,7 @@ pub fn filter_map_async<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
 ) -> Handler<'a, Output, Descr>
 where
-    Projection: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
+    Projection: Injectable<Option<NewType>, Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
     NewType: Send + Sync + 'static,
@@ -48,7 +50,7 @@ pub fn filter_map_with_description<'a, Projection, Output, NewType, Args, Descr>
     proj: Projection,
 ) -> Handler<'a, Output, Descr>
 where
-    Asyncify<Projection>: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
+    Asyncify<Projection>: Injectable<Option<NewType>, Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     NewType: Send + Sync + 'static,
 {
@@ -63,7 +65,7 @@ pub fn filter_map_async_with_description<'a, Projection, Output, NewType, Args, 
     proj: Projection,
 ) -> Handler<'a, Output, Descr>
 where
-    Projection: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
+    Projection: Injectable<Option<NewType>, Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     NewType: Send + Sync + 'static,
 {

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -93,7 +93,8 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_inspect() {
         let value = 123;
         let inspect_passed = Arc::new(AtomicBool::new(false));

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -93,21 +93,21 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_inspect() {
-        let value = 123;
-        let inspect_passed = Arc::new(AtomicBool::new(false));
-        let inspect_passed_cloned = Arc::clone(&inspect_passed);
+    crate::cross_test! {
+        async fn test_inspect() {
+            let value = 123;
+            let inspect_passed = Arc::new(AtomicBool::new(false));
+            let inspect_passed_cloned = Arc::clone(&inspect_passed);
 
-        let result: ControlFlow<(), _> = help_inference(inspect(move |x: i32| {
-            assert_eq!(x, value);
-            inspect_passed_cloned.swap(true, Ordering::Relaxed);
-        }))
-        .dispatch(deps![value])
-        .await;
+            let result: ControlFlow<(), _> = help_inference(inspect(move |x: i32| {
+                assert_eq!(x, value);
+                inspect_passed_cloned.swap(true, Ordering::Relaxed);
+            }))
+            .dispatch(deps![value])
+            .await;
 
-        assert!(matches!(result, ControlFlow::Continue(_)));
-        assert!(inspect_passed.load(Ordering::Relaxed));
+            assert!(matches!(result, ControlFlow::Continue(_)));
+            assert!(inspect_passed.load(Ordering::Relaxed));
+        }
     }
 }

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -1,6 +1,8 @@
 use crate::{
     di::{Asyncify, Injectable},
-    from_fn_with_description, Handler, HandlerDescription, HandlerSignature,
+    from_fn_with_description,
+    send::{MaybeSend, MaybeSync},
+    Handler, HandlerDescription, HandlerSignature,
 };
 
 use std::{collections::BTreeSet, sync::Arc};
@@ -13,7 +15,7 @@ use std::{collections::BTreeSet, sync::Arc};
 #[track_caller]
 pub fn inspect<'a, F, Output, Args, Descr>(f: F) -> Handler<'a, Output, Descr>
 where
-    Asyncify<F>: Injectable<(), Args> + Send + Sync + 'a,
+    Asyncify<F>: Injectable<(), Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
@@ -25,7 +27,7 @@ where
 #[track_caller]
 pub fn inspect_async<'a, F, Output, Args, Descr>(f: F) -> Handler<'a, Output, Descr>
 where
-    F: Injectable<(), Args> + Send + Sync + 'a,
+    F: Injectable<(), Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
@@ -40,7 +42,7 @@ pub fn inspect_with_description<'a, F, Output, Args, Descr>(
     f: F,
 ) -> Handler<'a, Output, Descr>
 where
-    Asyncify<F>: Injectable<(), Args> + Send + Sync + 'a,
+    Asyncify<F>: Injectable<(), Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
 {
     inspect_async_with_description(description, Asyncify(f))
@@ -54,7 +56,7 @@ pub fn inspect_async_with_description<'a, F, Output, Args, Descr>(
     f: F,
 ) -> Handler<'a, Output, Descr>
 where
-    F: Injectable<(), Args> + Send + Sync + 'a,
+    F: Injectable<(), Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
 {
     let f = Arc::new(f);

--- a/src/handler/map.rs
+++ b/src/handler/map.rs
@@ -105,7 +105,8 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_map() {
         let value = 123;
 

--- a/src/handler/map.rs
+++ b/src/handler/map.rs
@@ -105,19 +105,19 @@ mod tests {
     use super::*;
     use crate::{deps, help_inference};
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_map() {
-        let value = 123;
+    crate::cross_test! {
+        async fn test_map() {
+            let value = 123;
 
-        let result = help_inference(map(move || value))
-            .endpoint(move |event: i32| async move {
-                assert_eq!(event, value);
-                value
-            })
-            .dispatch(deps![])
-            .await;
+            let result = help_inference(map(move || value))
+                .endpoint(move |event: i32| async move {
+                    assert_eq!(event, value);
+                    value
+                })
+                .dispatch(deps![])
+                .await;
 
-        assert!(result == ControlFlow::Break(value));
+            assert!(result == ControlFlow::Break(value));
+        }
     }
 }

--- a/src/handler/map.rs
+++ b/src/handler/map.rs
@@ -1,6 +1,8 @@
 use crate::{
     di::{Asyncify, Injectable},
-    from_fn_with_description, Handler, HandlerDescription, HandlerSignature, Type,
+    from_fn_with_description,
+    send::{MaybeSend, MaybeSync},
+    Handler, HandlerDescription, HandlerSignature, Type,
 };
 
 use std::{collections::BTreeSet, iter::FromIterator, ops::ControlFlow, sync::Arc};
@@ -17,7 +19,7 @@ pub fn map<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
 ) -> Handler<'a, Output, Descr>
 where
-    Asyncify<Projection>: Injectable<NewType, Args> + Send + Sync + 'a,
+    Asyncify<Projection>: Injectable<NewType, Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
     NewType: Send + Sync + 'static,
@@ -32,7 +34,7 @@ pub fn map_async<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
 ) -> Handler<'a, Output, Descr>
 where
-    Projection: Injectable<NewType, Args> + Send + Sync + 'a,
+    Projection: Injectable<NewType, Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
     NewType: Send + Sync + 'static,
@@ -48,7 +50,7 @@ pub fn map_with_description<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
 ) -> Handler<'a, Output, Descr>
 where
-    Asyncify<Projection>: Injectable<NewType, Args> + Send + Sync + 'a,
+    Asyncify<Projection>: Injectable<NewType, Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
     NewType: Send + Sync + 'static,
@@ -64,7 +66,7 @@ pub fn map_async_with_description<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
 ) -> Handler<'a, Output, Descr>
 where
-    Projection: Injectable<NewType, Args> + Send + Sync + 'a,
+    Projection: Injectable<NewType, Args> + MaybeSend + MaybeSync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
     NewType: Send + Sync + 'static,

--- a/src/handler/methods.rs
+++ b/src/handler/methods.rs
@@ -112,7 +112,8 @@ mod tests {
     use crate::{deps, help_inference};
 
     // Test that these methods just do compile.
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn test_methods() {
         let value = 42;
 

--- a/src/handler/methods.rs
+++ b/src/handler/methods.rs
@@ -1,5 +1,6 @@
 use crate::{
     di::{Asyncify, Injectable},
+    send::{MaybeSend, MaybeSync},
     Handler, HandlerDescription,
 };
 
@@ -13,7 +14,7 @@ where
     #[track_caller]
     pub fn filter<Pred, FnArgs>(self, pred: Pred) -> Handler<'a, Output, Descr>
     where
-        Asyncify<Pred>: Injectable<bool, FnArgs> + Send + Sync + 'a,
+        Asyncify<Pred>: Injectable<bool, FnArgs> + MaybeSend + MaybeSync + 'a,
     {
         self.chain(crate::filter(pred))
     }
@@ -23,7 +24,7 @@ where
     #[track_caller]
     pub fn filter_async<Pred, FnArgs>(self, pred: Pred) -> Handler<'a, Output, Descr>
     where
-        Pred: Injectable<bool, FnArgs> + Send + Sync + 'a,
+        Pred: Injectable<bool, FnArgs> + MaybeSend + MaybeSync + 'a,
     {
         self.chain(crate::filter_async(pred))
     }
@@ -33,7 +34,7 @@ where
     #[track_caller]
     pub fn filter_map<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Output, Descr>
     where
-        Asyncify<Proj>: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
+        Asyncify<Proj>: Injectable<Option<NewType>, Args> + MaybeSend + MaybeSync + 'a,
         NewType: Send + Sync + 'static,
     {
         self.chain(crate::filter_map(proj))
@@ -44,7 +45,7 @@ where
     #[track_caller]
     pub fn filter_map_async<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Output, Descr>
     where
-        Proj: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
+        Proj: Injectable<Option<NewType>, Args> + MaybeSend + MaybeSync + 'a,
         NewType: Send + Sync + 'static,
     {
         self.chain(crate::filter_map_async(proj))
@@ -55,7 +56,7 @@ where
     #[track_caller]
     pub fn map<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Output, Descr>
     where
-        Asyncify<Proj>: Injectable<NewType, Args> + Send + Sync + 'a,
+        Asyncify<Proj>: Injectable<NewType, Args> + MaybeSend + MaybeSync + 'a,
         NewType: Send + Sync + 'static,
     {
         self.chain(crate::map(proj))
@@ -66,7 +67,7 @@ where
     #[track_caller]
     pub fn map_async<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Output, Descr>
     where
-        Proj: Injectable<NewType, Args> + Send + Sync + 'a,
+        Proj: Injectable<NewType, Args> + MaybeSend + MaybeSync + 'a,
         NewType: Send + Sync + 'static,
     {
         self.chain(crate::map_async(proj))
@@ -77,7 +78,7 @@ where
     #[track_caller]
     pub fn inspect<F, Args>(self, f: F) -> Handler<'a, Output, Descr>
     where
-        Asyncify<F>: Injectable<(), Args> + Send + Sync + 'a,
+        Asyncify<F>: Injectable<(), Args> + MaybeSend + MaybeSync + 'a,
     {
         self.chain(crate::inspect(f))
     }
@@ -87,7 +88,7 @@ where
     #[track_caller]
     pub fn inspect_async<F, Args>(self, f: F) -> Handler<'a, Output, Descr>
     where
-        F: Injectable<(), Args> + Send + Sync + 'a,
+        F: Injectable<(), Args> + MaybeSend + MaybeSync + 'a,
     {
         self.chain(crate::inspect_async(f))
     }
@@ -97,7 +98,7 @@ where
     #[track_caller]
     pub fn endpoint<F, FnArgs>(self, f: F) -> Handler<'a, Output, Descr>
     where
-        F: Injectable<Output, FnArgs> + Send + Sync + 'a,
+        F: Injectable<Output, FnArgs> + MaybeSend + MaybeSync + 'a,
         Output: 'static,
     {
         self.chain(crate::endpoint(f))

--- a/src/handler/methods.rs
+++ b/src/handler/methods.rs
@@ -111,43 +111,43 @@ mod tests {
 
     use crate::{deps, help_inference};
 
-    // Test that these methods just do compile.
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn test_methods() {
-        let value = 42;
+    crate::cross_test! {
+        // Test that these methods just do compile.
+        async fn test_methods() {
+            let value = 42;
 
-        let _: ControlFlow<(), _> =
-            help_inference(crate::entry()).filter(|| true).dispatch(deps![value]).await;
+            let _: ControlFlow<(), _> =
+                help_inference(crate::entry()).filter(|| true).dispatch(deps![value]).await;
 
-        let _: ControlFlow<(), _> = help_inference(crate::entry())
-            .filter_async(|| async { true })
-            .dispatch(deps![value])
-            .await;
+            let _: ControlFlow<(), _> = help_inference(crate::entry())
+                .filter_async(|| async { true })
+                .dispatch(deps![value])
+                .await;
 
-        let _: ControlFlow<(), _> =
-            help_inference(crate::entry()).filter_map(|| Some("abc")).dispatch(deps![value]).await;
+            let _: ControlFlow<(), _> =
+                help_inference(crate::entry()).filter_map(|| Some("abc")).dispatch(deps![value]).await;
 
-        let _: ControlFlow<(), _> = help_inference(crate::entry())
-            .filter_map_async(|| async { Some("abc") })
-            .dispatch(deps![value])
-            .await;
+            let _: ControlFlow<(), _> = help_inference(crate::entry())
+                .filter_map_async(|| async { Some("abc") })
+                .dispatch(deps![value])
+                .await;
 
-        let _: ControlFlow<(), _> =
-            help_inference(crate::entry()).map(|| "abc").dispatch(deps![value]).await;
+            let _: ControlFlow<(), _> =
+                help_inference(crate::entry()).map(|| "abc").dispatch(deps![value]).await;
 
-        let _: ControlFlow<(), _> = help_inference(crate::entry())
-            .map_async(|| async { "abc" })
-            .dispatch(deps![value])
-            .await;
+            let _: ControlFlow<(), _> = help_inference(crate::entry())
+                .map_async(|| async { "abc" })
+                .dispatch(deps![value])
+                .await;
 
-        let _: ControlFlow<(), _> =
-            help_inference(crate::entry()).inspect(|| {}).dispatch(deps![value]).await;
+            let _: ControlFlow<(), _> =
+                help_inference(crate::entry()).inspect(|| {}).dispatch(deps![value]).await;
 
-        let _: ControlFlow<(), _> =
-            help_inference(crate::entry()).inspect_async(|| async {}).dispatch(deps![value]).await;
+            let _: ControlFlow<(), _> =
+                help_inference(crate::entry()).inspect_async(|| async {}).dispatch(deps![value]).await;
 
-        let _: ControlFlow<(), _> =
-            help_inference(crate::entry()).endpoint(|| async {}).dispatch(deps![value]).await;
+            let _: ControlFlow<(), _> =
+                help_inference(crate::entry()).endpoint(|| async {}).dispatch(deps![value]).await;
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!         .branch(smiles_handler())
 //!         .branch(sqrt_handler())
 //!         .branch(not_found_handler());
-//!     
+//!
 //!     assert_eq!(
 //!         web_server.dispatch(dptree::deps!["/smile"]).await,
 //!         ControlFlow::Break("🙃".to_owned())
@@ -58,6 +58,7 @@ mod handler;
 
 pub mod di;
 pub mod prelude;
+pub mod send;
 
 pub use handler::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 //! An implementation of the [chain (tree) of responsibility] pattern.
 //!
 //! [[`examples/web_server.rs`](https://github.com/teloxide/dptree/blob/master/examples/web_server.rs)]
-//! ```
+//! ```rust
 //! use dptree::prelude::*;
 //!
 //! type WebHandler = Endpoint<'static, String>;
 //!
 //! #[rustfmt::skip]
-//! #[tokio::main]
+//! #[tokio::main(flavor = "current_thread")]
 //! async fn main() {
 //!     let web_server = dptree::entry()
 //!         .branch(smiles_handler())
@@ -95,10 +95,10 @@ pub use handler::*;
 ///
 /// ## Examples
 ///
-/// ```
+/// ```rust
 /// use dptree::prelude::*;
 ///
-/// # #[tokio::main]
+/// # #[tokio::main(flavor = "current_thread")]
 /// # async fn main() {
 /// #[derive(Clone)]
 /// enum Command {
@@ -170,7 +170,8 @@ mod tests {
         Other,
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn handler_empty_variant() {
         let input = State::A;
         let h: crate::Handler<_> = case![State::A].endpoint(|| async move { 123 });
@@ -179,7 +180,8 @@ mod tests {
         assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn handler_single_fn_variant() {
         let input = State::B(42);
         let h: crate::Handler<_> = case![State::B(x)].endpoint(|x: i32| async move {
@@ -191,7 +193,8 @@ mod tests {
         assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn handler_single_fn_variant_trailing_comma() {
         let input = State::B(42);
         let h: crate::Handler<_> = case![State::B(x,)].endpoint(|(x,): (i32,)| async move {
@@ -203,7 +206,8 @@ mod tests {
         assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn handler_fn_variant() {
         let input = State::C(42, "abc");
         let h: crate::Handler<_> =
@@ -217,7 +221,8 @@ mod tests {
         assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn handler_single_struct_variant() {
         let input = State::D { foo: 42 };
         let h: crate::Handler<_> = case![State::D { foo }].endpoint(|x: i32| async move {
@@ -229,7 +234,8 @@ mod tests {
         assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn handler_single_struct_variant_trailing_comma() {
         let input = State::D { foo: 42 };
         #[rustfmt::skip] // rustfmt removes the trailing comma from `State::D { foo, }`, but it plays a vital role in this test.
@@ -242,7 +248,8 @@ mod tests {
         assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn handler_struct_variant() {
         let input = State::E { foo: 42, bar: "abc" };
         let h: crate::Handler<_> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,32 @@ macro_rules! case {
     };
 }
 
+/// Conditionally applies `#[tokio::test]`/`#[test]` for native builds
+/// and `#[wasm_bindgen_test]` for Wasm targets.
+#[cfg(test)]
+macro_rules! cross_test {
+    () => {};
+    ($(#[$($attr:tt)*])* async fn $name:ident() $body:block $($rest:tt)*) => {
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+        $(#[$($attr)*])*
+        async fn $name() $body
+
+        crate::cross_test! { $($rest)* }
+    };
+    ($(#[$($attr:tt)*])* fn $name:ident() $body:block $($rest:tt)*) => {
+        #[cfg_attr(not(target_arch = "wasm32"), test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+        $(#[$($attr)*])*
+        fn $name() $body
+
+        crate::cross_test! { $($rest)* }
+    };
+}
+
+#[cfg(test)]
+pub(crate) use cross_test;
+
 #[cfg(test)]
 mod tests {
     use std::ops::ControlFlow;
@@ -170,96 +196,84 @@ mod tests {
         Other,
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn handler_empty_variant() {
-        let input = State::A;
-        let h: crate::Handler<_> = case![State::A].endpoint(|| async move { 123 });
+    crate::cross_test! {
+        async fn handler_empty_variant() {
+            let input = State::A;
+            let h: crate::Handler<_> = case![State::A].endpoint(|| async move { 123 });
 
-        assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
-        assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
-    }
+            assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
+            assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn handler_single_fn_variant() {
-        let input = State::B(42);
-        let h: crate::Handler<_> = case![State::B(x)].endpoint(|x: i32| async move {
-            assert_eq!(x, 42);
-            123
-        });
-
-        assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
-        assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn handler_single_fn_variant_trailing_comma() {
-        let input = State::B(42);
-        let h: crate::Handler<_> = case![State::B(x,)].endpoint(|(x,): (i32,)| async move {
-            assert_eq!(x, 42);
-            123
-        });
-
-        assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
-        assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn handler_fn_variant() {
-        let input = State::C(42, "abc");
-        let h: crate::Handler<_> =
-            case![State::C(x, y)].endpoint(|(x, str): (i32, &'static str)| async move {
+        async fn handler_single_fn_variant() {
+            let input = State::B(42);
+            let h: crate::Handler<_> = case![State::B(x)].endpoint(|x: i32| async move {
                 assert_eq!(x, 42);
-                assert_eq!(str, "abc");
                 123
             });
 
-        assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
-        assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
-    }
+            assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
+            assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
+        }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn handler_single_struct_variant() {
-        let input = State::D { foo: 42 };
-        let h: crate::Handler<_> = case![State::D { foo }].endpoint(|x: i32| async move {
-            assert_eq!(x, 42);
-            123
-        });
-
-        assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
-        assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn handler_single_struct_variant_trailing_comma() {
-        let input = State::D { foo: 42 };
-        #[rustfmt::skip] // rustfmt removes the trailing comma from `State::D { foo, }`, but it plays a vital role in this test.
-        let h: crate::Handler<_> = case![State::D { foo, }].endpoint(|(x,): (i32,)| async move {
-            assert_eq!(x, 42);
-            123
-        });
-
-        assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
-        assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
-    }
-
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn handler_struct_variant() {
-        let input = State::E { foo: 42, bar: "abc" };
-        let h: crate::Handler<_> =
-            case![State::E { foo, bar }].endpoint(|(x, str): (i32, &'static str)| async move {
+        async fn handler_single_fn_variant_trailing_comma() {
+            let input = State::B(42);
+            let h: crate::Handler<_> = case![State::B(x,)].endpoint(|(x,): (i32,)| async move {
                 assert_eq!(x, 42);
-                assert_eq!(str, "abc");
                 123
             });
 
-        assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
-        assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
+            assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
+            assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
+        }
+
+        async fn handler_fn_variant() {
+            let input = State::C(42, "abc");
+            let h: crate::Handler<_> =
+                case![State::C(x, y)].endpoint(|(x, str): (i32, &'static str)| async move {
+                    assert_eq!(x, 42);
+                    assert_eq!(str, "abc");
+                    123
+                });
+
+            assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
+            assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
+        }
+
+        async fn handler_single_struct_variant() {
+            let input = State::D { foo: 42 };
+            let h: crate::Handler<_> = case![State::D { foo }].endpoint(|x: i32| async move {
+                assert_eq!(x, 42);
+                123
+            });
+
+            assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
+            assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
+        }
+
+        async fn handler_single_struct_variant_trailing_comma() {
+            let input = State::D { foo: 42 };
+            #[rustfmt::skip] // rustfmt removes the trailing comma from `State::D { foo, }`, but it plays a vital role in this test.
+            let h: crate::Handler<_> = case![State::D { foo, }].endpoint(|(x,): (i32,)| async move {
+                assert_eq!(x, 42);
+                123
+            });
+
+            assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
+            assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
+        }
+
+        async fn handler_struct_variant() {
+            let input = State::E { foo: 42, bar: "abc" };
+            let h: crate::Handler<_> =
+                case![State::E { foo, bar }].endpoint(|(x, str): (i32, &'static str)| async move {
+                    assert_eq!(x, 42);
+                    assert_eq!(str, "abc");
+                    123
+                });
+
+            assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
+            assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
+        }
     }
 }

--- a/src/send.rs
+++ b/src/send.rs
@@ -1,0 +1,35 @@
+//! Conditional `Send`/`Sync` helpers for wasm32 target.
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// `Send` on native targets; no bound on `wasm32`.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSend: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send + ?Sized> MaybeSend for T {}
+
+/// `Send` on native targets; no bound on `wasm32`.
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSend {}
+#[cfg(target_arch = "wasm32")]
+impl<T: ?Sized> MaybeSend for T {}
+
+/// `Sync` on native targets; no bound on `wasm32`.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSync: Sync {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Sync + ?Sized> MaybeSync for T {}
+
+/// `Sync` on native targets; no bound on `wasm32`.
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSync {}
+#[cfg(target_arch = "wasm32")]
+impl<T: ?Sized> MaybeSync for T {}
+
+/// A boxed future that is `Send` on native targets and not required to be `Send`
+/// on `wasm32`.
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;


### PR DESCRIPTION
Introduces `MaybeSend`/`MaybeSync` traits and a conditional `BoxFuture` alias so handler and future bounds relax to nothing on `wasm32-unknown-unknown` while remaining identical to Send/Sync on native targets.

This lets `!Send` futures flow through handlers on `wasm32` without any unsafe.